### PR TITLE
Fix refresh token time inconsistency when initializing

### DIFF
--- a/extra_docs/examples/javascript/browser/browser-example.html
+++ b/extra_docs/examples/javascript/browser/browser-example.html
@@ -3,9 +3,13 @@
       <script src="../../../../dist/bundle/browser.js"></script>
   </head>
   <body>
-    <a href="#" id="authorize">Authorize</a>
+    <i>loading...</i>
     <script type="text/javascript">
-      document.getElementById("authorize").onclick = function(){
+      window.onload = function(){
+        if(!jexia) {
+          throw new Error("Please run `npm run build` task before run this example.");
+        }
+
         //Initialize dataOperationsModule
         let dom = jexia.dataOperations();
         let credentials = {
@@ -22,7 +26,10 @@
               document.write("<ul><li>" + item.title + "</li></ul>");
             }
           })
-          .catch(error => console.log(error));
+          .catch(error => {
+            document.write(error);
+            console.log(error);
+          });
       }
     </script>
   </body>

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "lint": "tslint \"src/**/*.ts\" \"spec/**/*.ts\"",
     "test": "jest",
     "test:ci": "jest --no-cache --ci --testResultsProcessor=\"jest-junit\"",
-    "tdd": "jest --watch",
+    "tdd": "jest --no-cache --watch",
     "tsnode": "ts-node --project tsconfig.examples.json -r tsconfig-paths/register",
     "preexample": "npm run build:main",
     "example": "node extra_docs/examples/javascript/node/node-example.js",

--- a/src/api/core/tokenManager.spec.ts
+++ b/src/api/core/tokenManager.spec.ts
@@ -38,23 +38,21 @@ describe("Class: TokenManager", () => {
       tm = new TokenManager(requestAdapterMockFactory().succesfulExecution({token: "validToken", refresh_token: "validRefreshToken"}));
     });
 
-    it("should throw an error if application URL is not provided", (done) => {
-      (new TokenManager(requestAdapterMockFactory().genericSuccesfulExecution()))
+    it("should throw an error if application URL is not provided", async () => {
+      await (new TokenManager(requestAdapterMockFactory().genericSuccesfulExecution()))
         .init({projectID: "", key: "validKey", secret: "validSecret"})
-        .then(() => done.fail("should throw app URL error"))
+        .then(() => { throw new Error("should have throw app URL error"); })
         .catch((err: Error) => {
           expect(err).toEqual(new Error("Please supply a valid Jexia project ID."));
-          done();
         });
     });
 
-    it("should throw an error if key or secret is not provided", (done) => {
-      (new TokenManager(requestAdapterMockFactory().genericSuccesfulExecution()))
+    it("should throw an error if key or secret is not provided", async () => {
+      await (new TokenManager(requestAdapterMockFactory().genericSuccesfulExecution()))
         .init({projectID: validProjectID, key: "", secret: ""})
-        .then(() => done.fail("should throw credentials error"))
+        .then(() => { throw new Error("should have throw authentication error"); })
         .catch((err: Error) => {
           expect(err).toEqual(new Error("Please provide valid application credentials."));
-          done();
         });
     });
 
@@ -68,18 +66,57 @@ describe("Class: TokenManager", () => {
         });
     });
 
-    it("should have valid token and refresh token if authorization succeeded", (done) => {
-      tm.init({projectID: validProjectID, key: "validKey", secret: "validSecret"})
-        .then((output: TokenManager) => {
-          expect(output instanceof TokenManager).toBe(true);
-          return output["tokens"];
-        })
-        .then((tokens: IAuthToken) => {
-          expect(tokens.token).toBe("validToken");
-          expect(tokens.refreshToken).toBe("validRefreshToken");
-          done();
-        })
-        .catch((err: Error) => done.fail(`init should not have failed: ${err.message}`));
+    it("should try login when storage has no token", async () => {
+      spyOn(TokenStorage.getStorageAPI(), "isEmpty").and.returnValue(true);
+      spyOn(tm as any, "login").and.returnValue(Promise.resolve());
+      const opts = { ...validOpts(), authMethod: () => authMethodMock().authMethod };
+      await tm.init(opts);
+      expect(tm["login"]).toHaveBeenLastCalledWith(opts);
+    });
+
+    it("should fail initialization when login fails", async () => {
+      spyOn(TokenStorage.getStorageAPI(), "isEmpty").and.returnValue(true);
+      const loginError = "loginError";
+      spyOn(tm as any, "login").and.returnValue(Promise.reject(loginError));
+      const opts = { ...validOpts(), authMethod: () => authMethodMock().authMethod };
+      try {
+        await tm.init(opts);
+        throw new Error("init should have failed!");
+      } catch (error) {
+        expect(error).toBe(loginError);
+      }
+    });
+
+    it("should try refresh session when storage has no token", async () => {
+      spyOn(TokenStorage.getStorageAPI(), "isEmpty").and.returnValue(false);
+      spyOn(tm as any, "refresh").and.returnValue(Promise.resolve());
+      const opts = { ...validOpts(), authMethod: () => authMethodMock().authMethod };
+      await tm.init(opts);
+      expect(tm["refresh"]).toHaveBeenLastCalledWith(opts.projectID);
+    });
+
+    it("should fail initialization when refresh session fails", async () => {
+      spyOn(TokenStorage.getStorageAPI(), "isEmpty").and.returnValue(false);
+      const loginError = "loginError";
+      spyOn(tm as any, "refresh").and.returnValue(Promise.reject(loginError));
+      const opts = { ...validOpts(), authMethod: () => authMethodMock().authMethod };
+      try {
+        await tm.init(opts);
+        throw new Error("init should have failed!");
+      } catch (error) {
+        expect(error).toBe(loginError);
+      }
+    });
+
+    it("should result itself at then promise when authorization succeeded", async () => {
+      const result = await tm.init(validOpts());
+      expect(result).toBe(tm);
+    });
+
+    it("should have valid token and refresh token if authorization succeeded", async () => {
+      const tokens = await tm.init(validOpts()).then((out) => out["tokens"]);
+      expect(tokens.token).toBe("validToken");
+      expect(tokens.refreshToken).toBe("validRefreshToken");
     });
 
     it("should throw an error if the token is accessed before login", (done) => {
@@ -161,19 +198,31 @@ describe("Class: TokenManager", () => {
 
   describe("when refreshing the token", () => {
     it("should use the auth method adapter correct", (done) => {
-      const { authMethod, resultValue } = authMethodMock();
+      const { authMethod } = authMethodMock();
       const opts = { ...validOpts(), authMethod: () => authMethod };
       const tm = tokenManagerWithTokens();
-      spyOn(tm["storage"], "setTokens");
       tm.init(opts)
-        .then((tokenManager) => {
-          const tokens = tokenManager["tokens"];
+        .then(({ tokens, requestAdapter }) => {
           setTimeout(() => {
             expect(authMethod.refresh).toHaveBeenCalledWith(
               tokens,
-              tokenManager["requestAdapter"],
+              requestAdapter,
               opts.projectID,
             );
+            done();
+          }, opts.refreshInterval + 10);
+        })
+        .catch((err: Error) => done.fail(`init should not have failed: ${err.message}`));
+    });
+
+    it("should set the new tokens after a success refresh", (done) => {
+      const { authMethod, resultValue } = authMethodMock();
+      const opts = { ...validOpts(), authMethod: () => authMethod };
+      const tm = tokenManagerWithTokens();
+      tm.init(opts)
+        .then(({ tokens, requestAdapter }) => {
+          spyOn(tm["storage"], "setTokens");
+          setTimeout(() => {
             expect(tm["storage"].setTokens).toHaveBeenCalledWith(resultValue);
             done();
           }, opts.refreshInterval + 10);
@@ -183,7 +232,7 @@ describe("Class: TokenManager", () => {
 
     it("should throw an error on refresh token failure", (done) => {
       tokenManagerWithTokens()
-        .init({projectID: validProjectID, key: "validKey", secret: "validSecret"})
+        .init(validOpts())
         .then((tokenManager: TokenManager) => {
           tokenManager["requestAdapter"] = requestAdapterMockFactory().failedExecution("refresh error.");
           tokenManager["refresh"](validProjectID)
@@ -197,18 +246,17 @@ describe("Class: TokenManager", () => {
     });
 
     it("should have updated token after successful auto refresh", (done) => {
+      const { authMethod, resultValue } = authMethodMock();
+      const opts = validOpts();
       tokenManagerWithTokens()
-        .init(validOpts())
+        .init({ ...opts, authMethod: () => authMethod })
         .then((tokenManager: TokenManager) => {
+          spyOn(tokenManager["storage"], "setTokens");
           tokenManager["requestAdapter"] = requestAdapterMockFactory().succesfulExecution({token: "updatedToken", refresh_token: "updatedRefreshToken"});
           setTimeout(() => {
-            tokenManager.token
-              .then((token: string) => {
-                expect(token).toBe("updatedToken");
-                done();
-              })
-              .catch((err: Error) => done.fail(`refresh should not have failed: ${err.message}`));
-          }, 700);
+            expect(tokenManager["storage"].setTokens).toHaveBeenLastCalledWith(resultValue);
+            done();
+          }, opts.refreshInterval + 10);
         })
         .catch((err: Error) => done.fail(`init should not have failed: ${err.message}`));
     });

--- a/src/api/core/tokenManager.ts
+++ b/src/api/core/tokenManager.ts
@@ -116,7 +116,7 @@ export class TokenManager {
       return Promise.reject(new Error("Please supply a valid Jexia project ID."));
     }
 
-    this.tokens = this.storage.isEmpty() ? this.login(opts) : this.storage.getTokens();
+    this.tokens = this.storage.isEmpty() ? this.login(opts) : this.refresh(opts.projectID);
 
     /* make sure that tokens have been successfully received */
     return this.tokens
@@ -127,7 +127,7 @@ export class TokenManager {
   public terminate(): void {
     this.storage.clear();
     clearInterval(this.refreshInterval);
-    delete this.tokens;
+    this.tokens = null as any;
   }
 
   private refreshToken(opts: IAuthOptions) {
@@ -143,12 +143,12 @@ export class TokenManager {
 
   private login(opts: IAuthOptions): Promise<IAuthToken> {
     /* no need to wait for tokens */
-    return this.authMethod.login(opts, this.requestAdapter).
-      then((tokens: IAuthToken) => this.storage.setTokens(tokens));
+    return this.authMethod.login(opts, this.requestAdapter)
+      .then((tokens: IAuthToken) => this.storage.setTokens(tokens));
   }
 
   private refresh(projectID: string): Promise<IAuthToken> {
-    return this.authMethod.refresh(this.tokens, this.requestAdapter, projectID).
-      then((tokens) => this.storage.setTokens(tokens));
+    return this.tokens = this.authMethod.refresh(this.storage.getTokens(), this.requestAdapter, projectID)
+      .then((tokens) => this.storage.setTokens(tokens));
   }
 }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[x] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Refresh token timer is reset with no information of how much time it lefts, and the current token can be invalid from the beginning or become invalid before the next refresh.

## What is the new behavior?

Always refresh the token when start the SDK.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

