### PR TITLE
Allow using any types for conditional methods

### DIFF
--- a/src/api/dataops/dataset.ts
+++ b/src/api/dataops/dataset.ts
@@ -13,6 +13,18 @@ import { UpdateQuery } from "./updateQuery";
 export type DefaultDatasetFields = "id" | "created_at" | "updated_at";
 
 /**
+ * Default dataset interface type
+ */
+export type DefaultDatasetInterface = {
+  [P in DefaultDatasetFields]: string;
+};
+
+/**
+ * Extend user provided interface (T) with default dataset fields
+ */
+export type DatasetInterface<T> = T & DefaultDatasetInterface;
+
+/**
  * Dataset object used to fetch and modify data at your datasets.
  * For TypeScript users it implements a generic type T that represents your dataset, default to any.
  * This object must be build from the data operations module, never to be instantiated direct.
@@ -61,7 +73,7 @@ export class Dataset<T = any> implements IResource {
    * @returns Query object specialized for select statements.
    * With no filters set, returns all records in the selected dataset.
    */
-  public select(): SelectQuery<T> {
+  public select(): SelectQuery<DatasetInterface<T>> {
     return new SelectQuery(this.requestExecuter, this.datasetName);
   }
 
@@ -71,13 +83,13 @@ export class Dataset<T = any> implements IResource {
    * @returns Query object specialized for update statements.
    * Don't forget to apply a filter to specify the fields that will be modified.
    */
-  public update(data: T): UpdateQuery<T> {
+  public update(data: DatasetInterface<T>): UpdateQuery<DatasetInterface<T>> {
     return new UpdateQuery(this.requestExecuter, data, this.datasetName);
   }
 
   /**
    * Creates an Insert query.
-   * @param data An array of dictionaries that contains the key:value pairs for
+   * @param records An array of dictionaries that contains the key:value pairs for
    * the fields that you want to store at this dataset
    * @returns Query object specialized for insert statements
    * If saving into a strict schema dataset, you need to provide values for the
@@ -93,7 +105,7 @@ export class Dataset<T = any> implements IResource {
    * You need to specify a filter to narrow down the records that you want deleted
    * from the backend.
    */
-  public delete(): DeleteQuery<T> {
+  public delete(): DeleteQuery<DatasetInterface<T>> {
     return new DeleteQuery(this.requestExecuter, this.datasetName);
   }
 }

--- a/src/api/dataops/deleteQuery.ts
+++ b/src/api/dataops/deleteQuery.ts
@@ -1,7 +1,6 @@
 import { MESSAGE } from "../../config/message";
 import { RequestExecuter } from "../../internal/executer";
 import { DataRequest } from "./dataRequest";
-import { DefaultDatasetFields } from "./dataset";
 import { FieldFilter, IFilteringCriterion, IFilteringCriterionCallback } from "./filteringApi";
 import { IExecutable, IFields, IFilterable, ILimit, IOffset, ISortable } from "./query.interfaces";
 
@@ -38,16 +37,16 @@ export class DeleteQuery<T = any> implements IFields<T>, ILimit, IOffset, IFilte
    * Select the fields to be returned at the response that represent the affected data
    * @param fields fields names
    */
-  public fields<K extends keyof T>(fields: Array<K | DefaultDatasetFields>): this;
-  public fields<K extends keyof T>(...fields: Array<K | DefaultDatasetFields>): this;
-  public fields<K extends keyof T>(field: K | DefaultDatasetFields, ...fields: Array<K | DefaultDatasetFields>): this {
+  public fields<K extends keyof T>(fields: K[]): this;
+  public fields<K extends keyof T>(...fields: K[]): this;
+  public fields<K extends keyof T>(field: K, ...fields: K[]): this {
     this.request.Query.Fields = Array.isArray(field) ? field : [field, ...fields];
     return this;
   }
 
   /**
    * Limit the operation for the first n records
-   * @param fields fields names
+   * @param limit number limit records amount
    */
   public limit(limit: number): this {
     this.request.Query.Limit = limit;
@@ -55,8 +54,8 @@ export class DeleteQuery<T = any> implements IFields<T>, ILimit, IOffset, IFilte
   }
 
   /**
-   * Limit the operation for the last n records
-   * @param fields fields names
+   * Offset selection with the offset records
+   * @param offset number offset amount
    */
   public offset(offset: number): this {
     this.request.Query.Offset = offset;
@@ -67,11 +66,11 @@ export class DeleteQuery<T = any> implements IFields<T>, ILimit, IOffset, IFilte
    * Filter the dataset rows with some conditions where the operation will be applied
    * @param filter Filtering criteria or a callback that returns a filtering criteria with the conditions
    */
-  public where<K extends keyof T>(
-    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T, K>): this {
+  public where(
+    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>): this {
     this.request.Query.setFilterCriteria(
       typeof filter === "function" ?
-        filter((field) => new FieldFilter<T, K>(field)) :
+        filter((field) => new FieldFilter(field)) :
         filter,
     );
     return this;
@@ -81,9 +80,9 @@ export class DeleteQuery<T = any> implements IFields<T>, ILimit, IOffset, IFilte
    * Sort ascendent the response that will represent the affected data
    * @param fields fields names to sort with
    */
-  public sortAsc<K extends keyof T>(fields: Array<K | DefaultDatasetFields>): this;
-  public sortAsc<K extends keyof T>(...fields: Array<K | DefaultDatasetFields>): this;
-  public sortAsc<K extends keyof T>(field: K | DefaultDatasetFields, ...fields: Array<K | DefaultDatasetFields>): this {
+  public sortAsc<K extends keyof T>(fields: K[]): this;
+  public sortAsc<K extends keyof T>(...fields: K[]): this;
+  public sortAsc<K extends keyof T>(field: K, ...fields: K[]): this {
     if (!field || field.length === 0) {
       throw new Error(MESSAGE.QUERY.MUST_PROVIDE_SORTING_FIELD);
     }
@@ -95,10 +94,10 @@ export class DeleteQuery<T = any> implements IFields<T>, ILimit, IOffset, IFilte
    * Sort decedent the response that will represent the affected data
    * @param fields fields names to sort with
    */
-  public sortDesc<K extends keyof T>(fields: Array<K | DefaultDatasetFields>): this;
-  public sortDesc<K extends keyof T>(...fields: Array<K | DefaultDatasetFields>): this;
+  public sortDesc<K extends keyof T>(fields: K[]): this;
+  public sortDesc<K extends keyof T>(...fields: K[]): this;
   public sortDesc<K extends keyof T>(
-    field: K | DefaultDatasetFields, ...fields: Array<K | DefaultDatasetFields>): this {
+    field: K, ...fields: K[]): this {
     if (!field || field.length === 0) {
       throw new Error(MESSAGE.QUERY.MUST_PROVIDE_SORTING_FIELD);
     }

--- a/src/api/dataops/filteringApi.spec.ts
+++ b/src/api/dataops/filteringApi.spec.ts
@@ -144,4 +144,97 @@ describe("FieldFilter class", () => {
     });
 
   });
+
+  describe("when building a filter with number type value", () => {
+    describe("greater than operator", () => {
+      it("should compile to the proper JSON", () => {
+        let filter = field("name").isGreaterThan(100);
+        let jsonResult: object = (filter as any).lowLevelCondition.compile();
+        expect(jsonResult as any).toEqual({ field: "name", operator: ">", values: [ 100 ], type: "and" });
+      });
+    });
+    describe("less than operator", () => {
+      it("should compile to the proper JSON", () => {
+        let filter = field("name").isLessThan(100);
+        let jsonResult: object = (filter as any).lowLevelCondition.compile();
+        expect(jsonResult as any).toEqual({ field: "name", operator: "<", values: [ 100 ], type: "and" });
+      });
+    });
+    describe("is equal to operator", () => {
+      it("should compile to the proper JSON", () => {
+        let filter = field("name").isEqualTo(100);
+        let jsonResult: object = (filter as any).lowLevelCondition.compile();
+        expect(jsonResult as any).toEqual({ field: "name", operator: "=", values: [ 100 ], type: "and" });
+      });
+    });
+  });
+
+  describe("when building a filter with boolean type value", () => {
+    describe("is equal to operator", () => {
+      it("should compile to the proper JSON", () => {
+        let filter = field("name").isEqualTo(true);
+        let jsonResult: object = (filter as any).lowLevelCondition.compile();
+        expect(jsonResult as any).toEqual({ field: "name", operator: "=", values: [ true ], type: "and" });
+      });
+    });
+    describe("is not equal to operator", () => {
+      it("should compile to the proper JSON", () => {
+        let filter = field("name").isDifferentFrom(false);
+        let jsonResult: object = (filter as any).lowLevelCondition.compile();
+        expect(jsonResult as any).toEqual({ field: "name", operator: "<>", values: [ false ], type: "and" });
+      });
+    });
+  });
+
+  describe("when building a filter with Date type value", () => {
+    let date = new Date();
+    describe("greater than operator", () => {
+      it("should compile to the proper JSON", () => {
+        let filter = field("name").isGreaterThan(date);
+        let jsonResult: object = (filter as any).lowLevelCondition.compile();
+        expect(jsonResult as any).toEqual({ field: "name", operator: ">", values: [ date ], type: "and" });
+      });
+    });
+    describe("less than operator", () => {
+      it("should compile to the proper JSON", () => {
+        let filter = field("name").isLessThan(date);
+        let jsonResult: object = (filter as any).lowLevelCondition.compile();
+        expect(jsonResult as any).toEqual({ field: "name", operator: "<", values: [ date ], type: "and" });
+      });
+    });
+    describe("is equal to operator", () => {
+      it("should compile to the proper JSON", () => {
+        let filter = field("name").isEqualTo(date);
+        let jsonResult: object = (filter as any).lowLevelCondition.compile();
+        expect(jsonResult as any).toEqual({ field: "name", operator: "=", values: [ date ], type: "and" });
+      });
+    });
+    describe("is between operator", () => {
+      it("should compile to the proper JSON", () => {
+        let date2 = new Date();
+        let filter = field("name").isBetween(date, date2);
+        let jsonResult: object = (filter as any).lowLevelCondition.compile();
+        expect(jsonResult as any).toEqual({ field: "name", operator: "BETWEEN", values: [ date, date2 ], type: "and" });
+      });
+    });
+  });
+
+  describe("when building a filter with object type value", () => {
+    describe("is equal to operator", () => {
+      it("should compile to the proper JSON", () => {
+        let filter = field("name").isEqualTo({ name: "Peter Jackson" });
+        let jsonResult: object = (filter as any).lowLevelCondition.compile();
+        expect(jsonResult as any)
+          .toEqual({ field: "name", operator: "=", values: [ { name: "Peter Jackson" } ], type: "and" });
+      });
+    });
+    describe("is not equal to operator", () => {
+      it("should compile to the proper JSON", () => {
+        let filter = field("name").isDifferentFrom({ name: "Peter Jackson" });
+        let jsonResult: object = (filter as any).lowLevelCondition.compile();
+        expect(jsonResult as any)
+          .toEqual({ field: "name", operator: "<>", values: [ { name: "Peter Jackson" } ], type: "and" });
+      });
+    });
+  });
 });

--- a/src/api/dataops/filteringApi.ts
+++ b/src/api/dataops/filteringApi.ts
@@ -1,34 +1,34 @@
 // tslint:disable:max-classes-per-file
-import { DefaultDatasetFields } from "jexia-sdk-js/api/dataops/dataset";
+import { DatasetInterface } from "jexia-sdk-js/api/dataops/dataset";
 import { CompositeFilteringCondition, FilteringCondition, ICondition } from "./filteringCondition";
 
 /**
  * @internal
  */
-export class FieldFilter<T, K extends keyof T> implements IFieldFilter {
-  constructor(private fieldName: K | DefaultDatasetFields) {}
+export class FieldFilter<U> {
+  constructor(private fieldName: string) {}
 
-  public isGreaterThan(value: string): IFilteringCriterion {
+  public isGreaterThan(value: U): IFilteringCriterion {
     return new FilteringCriterion(new FilteringCondition(this.fieldName, ">", [value]));
   }
 
-  public isLessThan(value: string): IFilteringCriterion {
+  public isLessThan(value: U): IFilteringCriterion {
     return new FilteringCriterion(new FilteringCondition(this.fieldName, "<", [value]));
   }
 
-  public isEqualTo(value: string): IFilteringCriterion {
+  public isEqualTo(value: U): IFilteringCriterion {
     return new FilteringCriterion(new FilteringCondition(this.fieldName, "=", [value]));
   }
 
-  public isDifferentFrom(value: string): IFilteringCriterion {
+  public isDifferentFrom(value: U): IFilteringCriterion {
     return new FilteringCriterion(new FilteringCondition(this.fieldName, "<>", [value]));
   }
 
-  public isEqualOrGreaterThan(value: string): IFilteringCriterion {
+  public isEqualOrGreaterThan(value: U): IFilteringCriterion {
     return new FilteringCriterion(new FilteringCondition(this.fieldName, ">=", [value]));
   }
 
-  public isEqualOrLessThan(value: string): IFilteringCriterion {
+  public isEqualOrLessThan(value: U): IFilteringCriterion {
     return new FilteringCriterion(new FilteringCondition(this.fieldName, "<=", [value]));
   }
 
@@ -40,11 +40,11 @@ export class FieldFilter<T, K extends keyof T> implements IFieldFilter {
     return new FilteringCriterion(new FilteringCondition(this.fieldName, "IS_NOT_NULL", []));
   }
 
-  public isInArray(values: string[]): IFilteringCriterion {
+  public isInArray(values: U[]): IFilteringCriterion {
     return new FilteringCriterion(new FilteringCondition(this.fieldName, "IN", values));
   }
 
-  public isNotInArray(values: string[]): IFilteringCriterion {
+  public isNotInArray(values: U[]): IFilteringCriterion {
     return new FilteringCriterion(new FilteringCondition(this.fieldName, "NOT_IN", values));
   }
 
@@ -56,7 +56,7 @@ export class FieldFilter<T, K extends keyof T> implements IFieldFilter {
     return new FilteringCriterion(new FilteringCondition(this.fieldName, "REGEXP", [regexp]));
   }
 
-  public isBetween(start: string, end: string): IFilteringCriterion {
+  public isBetween(start: U, end: U): IFilteringCriterion {
     return new FilteringCriterion(new FilteringCondition(this.fieldName, "BETWEEN", [start, end]));
   }
 }
@@ -104,78 +104,14 @@ export interface IFilteringCriterion<T = any> {
 }
 
 /**
- * Base interface for filtering by a dataset field
- *
- * @example
- * ```typescript
- * import { field } from "jexia-sdk-js/node";
- * const criterion = field("username").isEqualTo("Tom").or(field("username").isEqualTo("Dick"));
- * ```
- *
- * @template T Generic type of your dataset, default to any
- */
-export interface IFieldFilter<T = any> {
-  /**
-   * This field should be greater then the given value
-   */
-  isGreaterThan(value: string): IFilteringCriterion<T>;
-  /**
-   * This field should be lesser then the given value
-   */
-  isLessThan(value: string): IFilteringCriterion<T>;
-  /**
-   * This field should be equal to the given value
-   */
-  isEqualTo(value: string): IFilteringCriterion<T>;
-  /**
-   * This field should be different the given value
-   */
-  isDifferentFrom(value: string): IFilteringCriterion<T>;
-  /**
-   * This field should be equal or greater the given value
-   */
-  isEqualOrGreaterThan(value: string): IFilteringCriterion<T>;
-  /**
-   * This field should be equal of lesser then the given value
-   */
-  isEqualOrLessThan(value: string): IFilteringCriterion<T>;
-  /**
-   * This field should be null
-   */
-  isNull(): IFilteringCriterion<T>;
-  /**
-   * This field should be not null
-   */
-  isNotNull(): IFilteringCriterion<T>;
-  /**
-   * This field should have one of the given values
-   */
-  isInArray(values: string[]): IFilteringCriterion<T>;
-  /**
-   * This field should not have any of the given values
-   */
-  isNotInArray(values: string[]): IFilteringCriterion<T>;
-  /**
-   * This field should be contain the given value
-   */
-  isLike(value: string): IFilteringCriterion<T>;
-  /**
-   * This field should be satisfies the given regexp
-   */
-  satisfiesRegexp(regexp: string): IFilteringCriterion<T>;
-  /**
-   * This field should be in between these given values
-   */
-  isBetween(start: string, end: string): IFilteringCriterion<T>;
-}
-
-/**
  * Starts a filtering criteria for a given field
  * @param name Field name to be filtered
  * @template T Generic type of your dataset, default to any
+ * @template K Generic name of the dataset field you want to filter by
  */
-export function field<T = any>(name: string): IFieldFilter {
-  return new FieldFilter<T, any>(name);
+export function field<T = DatasetInterface<any>, K extends keyof DatasetInterface<T> = any>(name: K):
+  FieldFilter<DatasetInterface<T>[K]> {
+  return new FieldFilter<DatasetInterface<T>[K]>(name);
 }
 
 /**
@@ -185,8 +121,8 @@ export function field<T = any>(name: string): IFieldFilter {
  * @template T Generic type of your dataset, default to any
  * @template K Keys of the of your dataset, default to any
  */
-export type IFilteringCriterionCallback<T, K extends keyof T> =
-  (filter: (field: K | DefaultDatasetFields) => IFieldFilter<T>) => IFilteringCriterion<T>;
+export type IFilteringCriterionCallback<T> =
+  (filter: <K extends keyof T>(field: K) => FieldFilter<T[K]>) => IFilteringCriterion<T>;
 
 /**
  * Starts a filtering criteria combination with a filtering criteria

--- a/src/api/dataops/filteringCondition.spec.ts
+++ b/src/api/dataops/filteringCondition.spec.ts
@@ -8,7 +8,7 @@ describe("FilteringCondition class", () => {
   });
 
   describe("when compiling a simple condition", () => {
-    let condition: FilteringCondition;
+    let condition: FilteringCondition<string>;
     let field = "field";
     let operator = "operator";
     let value = "value";
@@ -23,7 +23,7 @@ describe("FilteringCondition class", () => {
   });
 
   describe("when adding a condition with the AND/OR methods", () => {
-    let condition: FilteringCondition;
+    let condition: FilteringCondition<string>;
     let field = "field";
     let operator = "operator";
     let value = "value";

--- a/src/api/dataops/filteringCondition.ts
+++ b/src/api/dataops/filteringCondition.ts
@@ -19,13 +19,13 @@ export type LogicalOperator = "and" | "or";
 /**
  * @internal
  */
-export class FilteringCondition implements ICondition {
+export class FilteringCondition<U> implements ICondition {
   private field: string;
   private operator: string;
-  private values: string[];
+  private values: U[];
   private logicalOperatorType: LogicalOperator;
 
-  constructor(field: string, operator: string, values: string[]) {
+  constructor(field: string, operator: string, values: U[]) {
     this.logicalOperatorType = "and";
     this.field = field;
     this.operator = operator;

--- a/src/api/dataops/query.interfaces.ts
+++ b/src/api/dataops/query.interfaces.ts
@@ -1,14 +1,13 @@
 import { Dataset } from "jexia-sdk-js/api/dataops/dataset";
-import { DefaultDatasetFields } from "jexia-sdk-js/api/dataops/dataset";
 import { IFilteringCriterion } from "jexia-sdk-js/api/dataops/filteringApi";
 
 /**
  * @internal
  */
 export interface IFields<T> {
-  fields<K extends keyof T>(fields: Array<K | DefaultDatasetFields>): this;
-  fields<K extends keyof T>(...fields: Array<K | DefaultDatasetFields>): this;
-  fields<K extends keyof T>(field: K | DefaultDatasetFields, ...fields: Array<K | DefaultDatasetFields>): this;
+  fields<K extends keyof T>(fields: K[]): this;
+  fields<K extends keyof T>(...fields: K[]): this;
+  fields<K extends keyof T>(field: K, ...fields: K[]): this;
 }
 
 /**
@@ -36,12 +35,12 @@ export interface IFilterable {
  * @internal
  */
 export interface ISortable<T> {
-  sortAsc<K extends keyof T>(fields: Array<K | DefaultDatasetFields>): this;
-  sortAsc<K extends keyof T>(...fields: Array<K | DefaultDatasetFields>): this;
-  sortAsc<K extends keyof T>(field: K | DefaultDatasetFields, ...fields: Array<K | DefaultDatasetFields>): this;
-  sortDesc<K extends keyof T>(fields: Array<K | DefaultDatasetFields>): this;
-  sortDesc<K extends keyof T>(...fields: Array<K | DefaultDatasetFields>): this;
-  sortDesc<K extends keyof T>(field: K | DefaultDatasetFields, ...fields: Array<K | DefaultDatasetFields>): this;
+  sortAsc<K extends keyof T>(fields: K[]): this;
+  sortAsc<K extends keyof T>(...fields: K[]): this;
+  sortAsc<K extends keyof T>(field: K, ...fields: K[]): this;
+  sortDesc<K extends keyof T>(fields: K[]): this;
+  sortDesc<K extends keyof T>(...fields: K[]): this;
+  sortDesc<K extends keyof T>(field: K, ...fields: K[]): this;
 }
 
 /**

--- a/src/api/dataops/selectQuery.ts
+++ b/src/api/dataops/selectQuery.ts
@@ -1,7 +1,7 @@
 import { MESSAGE } from "../../config/message";
 import { RequestExecuter } from "../../internal/executer";
 import { DataRequest } from "./dataRequest";
-import { Dataset, DefaultDatasetFields } from "./dataset";
+import { Dataset, DatasetInterface } from "./dataset";
 import { FieldFilter, IFilteringCriterion, IFilteringCriterionCallback } from "./filteringApi";
 import { IExecutable, IFields, IFilterable, ILimit, IOffset, IRelational, ISortable } from "./query.interfaces";
 
@@ -38,9 +38,9 @@ export class SelectQuery<T = any>
    * Select the fields to be returned at the response that represent the affected data
    * @param fields fields names
    */
-  public fields<K extends keyof T>(fields: Array<K | DefaultDatasetFields>): this;
-  public fields<K extends keyof T>(...fields: Array<K | DefaultDatasetFields>): this;
-  public fields<K extends keyof T>(field: K | DefaultDatasetFields, ...fields: Array<K | DefaultDatasetFields>): this {
+  public fields<K extends keyof T>(fields: K[]): this;
+  public fields<K extends keyof T>(...fields: K[]): this;
+  public fields<K extends keyof T>(field: K, ...fields: K[]): this {
     this.request.Query.Fields = Array.isArray(field) ? field : [field, ...fields];
     return this;
   }
@@ -67,11 +67,11 @@ export class SelectQuery<T = any>
    * Filter the dataset records with some conditions where the operation will be applied
    * @param filter Filtering criteria or a callback that returns a filtering criteria with the conditions
    */
-  public where<K extends keyof T>(
-    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T, K>): this {
+  public where(
+    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>): this {
     this.request.Query.setFilterCriteria(
       typeof filter === "function" ?
-        filter((field) => new FieldFilter<T, K>(field)) :
+        filter((field) => new FieldFilter(field)) :
         filter,
     );
     return this;
@@ -81,9 +81,9 @@ export class SelectQuery<T = any>
    * Sort ascendent the response that will represent the affected data
    * @param fields fields names to sort with
    */
-  public sortAsc<K extends keyof T>(fields: Array<K | DefaultDatasetFields>): this;
-  public sortAsc<K extends keyof T>(...fields: Array<K | DefaultDatasetFields>): this;
-  public sortAsc<K extends keyof T>(field: K | DefaultDatasetFields, ...fields: Array<K | DefaultDatasetFields>): this {
+  public sortAsc<K extends keyof T>(fields: K[]): this;
+  public sortAsc<K extends keyof T>(...fields: K[]): this;
+  public sortAsc<K extends keyof T>(field: K, ...fields: K[]): this {
     if (!field || field.length === 0) {
       throw new Error(MESSAGE.QUERY.MUST_PROVIDE_SORTING_FIELD);
     }
@@ -95,10 +95,10 @@ export class SelectQuery<T = any>
    * Sort decedent the response that will represent the affected data
    * @param fields fields names to sort with
    */
-  public sortDesc<K extends keyof T>(fields: Array<K | DefaultDatasetFields>): this;
-  public sortDesc<K extends keyof T>(...fields: Array<K | DefaultDatasetFields>): this;
+  public sortDesc<K extends keyof T>(fields: K[]): this;
+  public sortDesc<K extends keyof T>(...fields: K[]): this;
   public sortDesc<K extends keyof T>(
-    field: K | DefaultDatasetFields, ...fields: Array<K | DefaultDatasetFields>): this {
+    field: K, ...fields: K[]): this {
     if (!field || field.length === 0) {
       throw new Error(MESSAGE.QUERY.MUST_PROVIDE_SORTING_FIELD);
     }
@@ -113,7 +113,7 @@ export class SelectQuery<T = any>
    */
   public relation<R>(
     dataSet: Dataset<R>,
-    callback: (query: SelectQuery<R>) => SelectQuery<R> = (q) => q,
+    callback: (query: SelectQuery<DatasetInterface<R>>) => SelectQuery<DatasetInterface<R>> = (q) => q,
   ): this {
     let relation = callback(dataSet.select());
     this.request.Query.AddRelation(relation.request.Query);

--- a/src/api/dataops/updateQuery.ts
+++ b/src/api/dataops/updateQuery.ts
@@ -1,7 +1,6 @@
 import { MESSAGE } from "../../config/message";
 import { RequestExecuter } from "../../internal/executer";
 import { DataRequest } from "./dataRequest";
-import { DefaultDatasetFields } from "./dataset";
 import { FieldFilter, IFilteringCriterion, IFilteringCriterionCallback } from "./filteringApi";
 import { IExecutable, IFilterable, ILimit, IOffset, ISortable } from "./query.interfaces";
 
@@ -57,11 +56,11 @@ export class UpdateQuery<T = any> implements ILimit, IOffset, IFilterable, IExec
    * Filter the dataset records with some conditions where the operation will be applied
    * @param filter Filtering criteria or a callback that returns a filtering criteria with the conditions
    */
-  public where<K extends keyof T>(
-    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T, K>): this {
+  public where(
+    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>): this {
     this.request.Query.setFilterCriteria(
       typeof filter === "function" ?
-        filter((field) => new FieldFilter<T, K>(field)) :
+        filter((field) => new FieldFilter(field)) :
         filter,
     );
     return this;
@@ -71,9 +70,9 @@ export class UpdateQuery<T = any> implements ILimit, IOffset, IFilterable, IExec
    * Sort ascendent the response that will represent the affected data
    * @param fields fields names to sort with
    */
-  public sortAsc<K extends keyof T>(fields: Array<K | DefaultDatasetFields>): this;
-  public sortAsc<K extends keyof T>(...fields: Array<K | DefaultDatasetFields>): this;
-  public sortAsc<K extends keyof T>(field: K | DefaultDatasetFields, ...fields: Array<K | DefaultDatasetFields>): this {
+  public sortAsc<K extends keyof T>(fields: K[]): this;
+  public sortAsc<K extends keyof T>(...fields: K[]): this;
+  public sortAsc<K extends keyof T>(field: K, ...fields: K[]): this {
     if (!field || field.length === 0) {
       throw new Error(MESSAGE.QUERY.MUST_PROVIDE_SORTING_FIELD);
     }
@@ -85,10 +84,10 @@ export class UpdateQuery<T = any> implements ILimit, IOffset, IFilterable, IExec
    * Sort decedent the response that will represent the affected data
    * @param fields fields names to sort with
    */
-  public sortDesc<K extends keyof T>(fields: Array<K | DefaultDatasetFields>): this;
-  public sortDesc<K extends keyof T>(...fields: Array<K | DefaultDatasetFields>): this;
+  public sortDesc<K extends keyof T>(fields: K[]): this;
+  public sortDesc<K extends keyof T>(...fields: K[]): this;
   public sortDesc<K extends keyof T>(
-    field: K | DefaultDatasetFields, ...fields: Array<K | DefaultDatasetFields>): this {
+    field: K, ...fields: K[]): this {
     if (!field || field.length === 0) {
       throw new Error(MESSAGE.QUERY.MUST_PROVIDE_SORTING_FIELD);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ export { DataOperationsModule } from "./api/dataops/dataOperationsModule";
 export {
   combineCriteria,
   field,
-  IFieldFilter,
+  FieldFilter,
   IFilteringCriterion,
   IFilteringCriterionCallback,
 } from "./api/dataops/filteringApi";

--- a/src/internal/query.ts
+++ b/src/internal/query.ts
@@ -1,4 +1,3 @@
-import { DefaultDatasetFields } from "../api/dataops/dataset";
 import { IFilteringCriterion } from "../api/dataops/filteringApi";
 import { ICondition } from "../api/dataops/filteringCondition";
 import { MESSAGE } from "../config/message";
@@ -81,7 +80,7 @@ export class Query<T = any> {
     return this.relations;
   }
 
-  public AddSortCondition<K extends keyof T>(direction: "asc" | "desc", ...fields: Array<K | DefaultDatasetFields>) {
+  public AddSortCondition<K extends keyof T>(direction: "asc" | "desc", ...fields: K[]) {
     if (fields.length === 0) {
       throw new Error(MESSAGE.QUERY.MUST_PROVIDE_SORTING_FIELD);
     }


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behaviour?
Methods like `isEqualTo()` and others are able to handle only `string` type arguments 

<!-- Please describe the current behaviour that you are modifying or link to a relevant issue. -->

Issue https://github.com/jexia/jexia-sdk-js/issues/22

## What is the new behaviour?
Next methods accept any type of arguments:

* isGreaterThan
* isLessThan
* isEqualTo
* isDifferentFrom
* isEqualOrGreaterThan
* isEqualOrLessThan
* isNull
* isNotNull
* isInArray
* isNotInArray
* isBetween

These ones accept only string:

* isLike
* satisfiesRegexp

## Typescript feature
In case customer provides dataset interface, typescript will give a hint which type of argument allowed for certain dataset field.

Example:

```typescript
// Decalre dataset interface
interface User {
  email: string;
  password: string;
  isadmin: boolean;
  age: number;
}

// Provide interface to the datase init
let dataset = dom.dataset<User>("user");

let admins = await dataset
  .select()
  .where(field => field("isadmin").isEqualTo("yes")) // wrong type!
  .execute()
```

Typescript will give an error because `isadmin` field has boolean type: `TS2345: Argument of type 'string' is not assignable to parameter of type 'boolean'`

Correct types usage example:

```typescript
let youngsters = await dataset
  .select()
  .where(field => field("age").isBetween(22, 40) // Now types are ok
  .execute()
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
