### PR TITLE
Allow single record object notation for inserting records

### DIFF
--- a/extra_docs/quickstart.md
+++ b/extra_docs/quickstart.md
@@ -305,7 +305,7 @@ const insertQuery = posts.insert({
 insertQuery
   .execute()
   .then((records) => {
-    // you will be able to access the newly inserted records with their generated IDs
+    // you will always get an array of created records even when inserting a single record
   }).catch((error) => {
     // you can see the error info here, if something goes wrong
   });

--- a/extra_docs/quickstart.md
+++ b/extra_docs/quickstart.md
@@ -283,17 +283,32 @@ posts.select().relation(comments).execute().then( (records) => {
 
 ### Inserting records
 
+Records can be inserted to a dataset either by sending an array or a single one. The response will always be an array though.
+
 ``` Javascript
 [..]
-let posts = dataModule.dataset("posts");
-posts.insert([ {title: "New Post", content:"content here"}, 
-               {title: "Another Post", content:"some more content"} 
-]).execute().then( (records) => {
-  // you will be able to access the newly inserted records here
-  // complete with their generated IDs
-}).catch( (error) => {
-  // you can see the error info here, if something goes wrong
+const posts = dataModule.dataset("posts");
+
+// Multiple records
+const insertQuery = posts.insert([
+  { title: "New Post", content: "content here" },
+  { title: "Another Post", content: "some more content" },
+]);
+
+// Single record
+const insertQuery = posts.insert({
+  title: "New Post",
+  content: "content here",
 });
+
+// Either way, the response will be an array
+insertQuery
+  .execute()
+  .then((records) => {
+    // you will be able to access the newly inserted records with their generated IDs
+  }).catch((error) => {
+    // you can see the error info here, if something goes wrong
+  });
 [..]
 ```
 

--- a/src/api/dataops/dataset.spec.ts
+++ b/src/api/dataops/dataset.spec.ts
@@ -37,9 +37,14 @@ describe("Dataset class", () => {
     expect(dataset.update({}) instanceof UpdateQuery).toBeTruthy();
   });
 
-  it("should be able start a insert query", () => {
+  it("should be able start a insert query with an array of records", () => {
     const dataset = new Dataset("test", createMockFor(RequestExecuter));
     expect(dataset.insert([{}]) instanceof InsertQuery).toBeTruthy();
+  });
+
+  it("should be able start a insert query with a single record", () => {
+    const dataset = new Dataset("test", createMockFor(RequestExecuter));
+    expect(dataset.insert({}) instanceof InsertQuery).toBeTruthy();
   });
 
   it("should be able start a delete query", () => {

--- a/src/api/dataops/dataset.ts
+++ b/src/api/dataops/dataset.ts
@@ -93,14 +93,18 @@ export class Dataset<T extends object = any, D extends DatasetInterface<T> = Dat
 
   /**
    * Creates an Insert query.
-   * @param records An array of dictionaries that contains the key:value pairs for
-   * the fields that you want to store at this dataset
+   * @param data A dictionary that contains the key:value pairs for
+   * the fields you want to store at this dataset or an array of those.
    * @returns Query object specialized for insert statements
    * If saving into a strict schema dataset, you need to provide values for the
    * required fields for that particular dataset.
    */
-  public insert(records: T[]): InsertQuery<T, D> {
-    return new InsertQuery<T, D>(this.requestExecuter, records, this.datasetName);
+  public insert(data: T[] | T): InsertQuery<T, D> {
+    return new InsertQuery<T, D>(
+      this.requestExecuter,
+      Array.isArray(data) ? data : [data],
+      this.datasetName,
+    );
   }
 
   /**


### PR DESCRIPTION
First part for updating to the current dataset contracts, allowing user to insert records passing an array or an object.