### PR TITLE
feat(relation): populate nested resources

### DIFF
--- a/src/api/core/queries/filterableQuery.spec.ts
+++ b/src/api/core/queries/filterableQuery.spec.ts
@@ -1,5 +1,4 @@
 import * as faker from "faker";
-import { Dataset } from "../../..";
 import { createMockFor } from "../../../../spec/testUtils";
 import { RequestExecuter } from "../../../internal/executer";
 import { Query } from "../../../internal/query";
@@ -52,10 +51,6 @@ describe("QueryRequest class", () => {
   it("where method should be defined", () => {
     expect(subject.where).toBeDefined();
   });
-
-  it("relation method should be defined", () => {
-    expect(subject.relation).toBeDefined();
-  });
 });
 
 describe("when instantiating a select query object", () => {
@@ -75,28 +70,5 @@ describe("when instantiating a select query object", () => {
       return filter;
     });
     expect(queryMock.setFilterCriteria).toHaveBeenCalledWith(filter);
-  });
-
-  it("should throw an error if call relation method", () => {
-    const { subject } = createSubject();
-    expect(() => subject.relation({} as Dataset)).toThrow();
-  });
-
-  xit("should have the correct query for relation without configured query", () => {
-    const { subject } = createSubject({ createMockForQuery: false });
-    const testQuery = {};
-    const datasetMock = createMockFor(Dataset, { returnValue: { query: testQuery } });
-    const queryObj = subject.relation(datasetMock);
-    // tslint:disable-next-line:no-string-literal
-    expect(queryObj["query"]["relations"]).toEqual([testQuery]);
-  });
-
-  xit("should have the correct query for relation with configured query", () => {
-    const { subject } = createSubject({ createMockForQuery: false });
-    const testQuery = {};
-    const datasetMock = createMockFor(Dataset);
-    const queryObj = subject.relation(datasetMock, () => ({ query: testQuery } as any));
-    // tslint:disable-next-line:no-string-literal
-    expect(queryObj["query"]["relations"]).toEqual([testQuery]);
   });
 });

--- a/src/api/core/queries/filterableQuery.ts
+++ b/src/api/core/queries/filterableQuery.ts
@@ -1,7 +1,5 @@
-import { Dataset, DatasetInterface } from "../../dataops/dataset";
 import { FieldFilter, IFilteringCriterion, IFilteringCriterionCallback } from "../../dataops/filteringApi";
 import { BaseQuery } from "./baseQuery";
-import { SelectQuery } from "./selectQuery";
 
 /**
  * Extend `BaseQuery` and overrides `where()` and `relation()` methods. Used by `SELECT`, `UPDATE` and `DELETE` queries.
@@ -33,17 +31,5 @@ export abstract class FilterableQuery<T> extends BaseQuery<T> {
         filter,
     );
     return this;
-  }
-
-  /**
-   * Filter the dataset records with some conditions against a related dataset
-   * @param dataSet name of the related dataset
-   * @param callback callback that returns the select query for the related dataset
-   */
-  public relation<R extends object>(
-    dataSet: Dataset<R>,
-    callback: (query: SelectQuery<DatasetInterface<R>>) => SelectQuery<DatasetInterface<R>> = (q) => q,
-  ): this {
-    throw new Error("Relations are not supported in current version of SDK");
   }
 }

--- a/src/api/core/queries/relatedQuery.ts
+++ b/src/api/core/queries/relatedQuery.ts
@@ -1,0 +1,58 @@
+import { Query } from "../../../internal/query";
+
+/**
+ * RelatedQuery class provides nested resources fields population
+ * returned by SelectQuery related() method
+ * @internal
+ */
+export class RelatedQuery<R> {
+  constructor(
+    private resourceName: string,
+    private query: Query) {}
+
+  /**
+   * Select the fields to be returned and represent related resource data
+   *
+   * @param fields fields names or aggregation object
+   */
+  public fields(fields: R[]): this;
+  public fields(...fields: R[]): this;
+  public fields<K extends R>(field: K, ...fields: K[]): this {
+    const relatedFields = this.nestedFields(Array.isArray(field) ? field : [field, ...fields]);
+    this.query.fields.push(...relatedFields);
+    return this;
+  }
+
+  /**
+   * Allow to populate nested related resource fields
+   * @param {string} resourceName Related resource
+   * @param {function} callback Pass RelatedQuery object to the callback
+   * @example
+   *   dataset("posts")
+   *     .select()
+   *     .related("comments",
+   *        comments => comments
+   *          .related("author", author => author.fields("email"))
+   *          .fields("date", "text"))
+   *   execute();
+   *
+   */
+  public related(
+    resourceName: string,
+    callback: (q: RelatedQuery<any>) => RelatedQuery<any> = (related) => {
+      this.query.fields.push([this.resourceName, resourceName].join("."));
+      return related;
+    }): this {
+    // @ts-ignore
+    callback(new RelatedQuery([this.resourceName, resourceName].join("."), this.query));
+    return this;
+  }
+
+  /**
+   * Apply dot notation to each nested field
+   * @ignore
+   */
+  private nestedFields(fields: R[]): string[] {
+    return fields.map((field) => [this.resourceName, field].join("."));
+  }
+}

--- a/src/api/core/queries/selectQuery.spec.ts
+++ b/src/api/core/queries/selectQuery.spec.ts
@@ -104,6 +104,54 @@ describe("SelectQuery class", () => {
       });
     });
 
+    describe("nested relations", () => {
+      it("should add relation to the query", () => {
+        const { subject } = createSubject({ mockQuery: false });
+        subject.related("profile");
+        expect(subject["query"]["fields"]).toContain("profile");
+      });
+
+      it("should add relation fields to the query if they are provided", () => {
+        const { subject } = createSubject({ mockQuery: false });
+        subject.related("profile", (profile) => profile.fields("email"));
+        expect(subject["query"]["fields"]).toContain("profile.email");
+      });
+
+      it("should proceed an array of fields", () => {
+        const { subject } = createSubject({ mockQuery: false });
+        subject.related("profile", (profile) => profile.fields(["email", "age"]));
+        expect(subject["query"]["fields"]).toEqual(["profile.email", "profile.age"]);
+      });
+
+      it("should not add relation fields to the query if they were not provided", () => {
+        const { subject } = createSubject({ mockQuery: false });
+        subject.related("profile", (profile) => profile.fields("email"));
+        expect(subject["query"]["fields"]).not.toContain("profile.age");
+      });
+
+      it("should add nested relation", () => {
+        const { subject } = createSubject({ mockQuery: false });
+        subject.related("profile", (profile) => profile
+          .related("address"));
+        expect(subject["query"]["fields"]).toContain("profile.address");
+      });
+
+      it("should add nested relation fields", () => {
+        const { subject } = createSubject({ mockQuery: false });
+        subject.related("profile", (profile) => profile
+          .related("address", (address) => address
+            .fields("city")));
+        expect(subject["query"]["fields"]).toContain("profile.address.city");
+      });
+
+      it("should not add not provided nested relation fields", () => {
+        const { subject } = createSubject({ mockQuery: false });
+        subject.related("profile", (profile) => profile
+          .related("address", (address) => address
+            .fields("city")));
+        expect(subject["query"]["fields"]).not.toContain("profile.address.building");
+      });
+    });
   });
 
   it("should correct execute the query", () => {

--- a/src/api/core/queries/selectQuery.ts
+++ b/src/api/core/queries/selectQuery.ts
@@ -1,8 +1,9 @@
 import { MESSAGE } from "../../../config/message";
 import { RequestExecuter } from "../../../internal/executer";
-import { ResourceType } from "../resource";
+import { FromRelated, ResourceType } from "../resource";
 import { QueryAction } from "./baseQuery";
 import { FilterableQuery } from "./filterableQuery";
+import { RelatedQuery } from "./relatedQuery";
 
 /**
  * Query object specialized for select statements.
@@ -70,6 +71,29 @@ export class SelectQuery<T> extends FilterableQuery<T> {
       throw new Error(MESSAGE.QUERY.MUST_PROVIDE_SORTING_FIELD);
     }
     this.query.addSortCondition("desc", ...(Array.isArray(field) ? field : field && [field, ...fields]));
+    return this;
+  }
+
+  /**
+   * Allow to populate related resource fields
+   * @param {string} resourceName Related resource
+   * @param {function} callback Pass RelatedQuery object to the callback
+   * @example
+   *   dataset("posts")
+   *     .select()
+   *     .related("comments", comments => comments.fields("author", "date", "text"))
+   *   execute();
+   *
+   */
+  public related<R extends keyof T>(
+    resourceName: R,
+    callback: (q: RelatedQuery<FromRelated<T[R]>>) => RelatedQuery<FromRelated<T[R]>> = (related) => {
+      // @ts-ignore // TODO typescript issue, upgrade TS
+      this.query.fields.push(resourceName);
+      return related;
+    }): this {
+    // @ts-ignore
+    callback(new RelatedQuery<FromRelated<T[R]>>(resourceName, this.query));
     return this;
   }
 }

--- a/src/api/core/resource.ts
+++ b/src/api/core/resource.ts
@@ -19,3 +19,26 @@ export interface IResource {
    */
   resourceType: ResourceType;
 }
+
+/**
+ * Default fields that will always exist for any resource
+ */
+export type DefaultResourceFields = "id" | "created_at" | "updated_at";
+
+/**
+ * Default resource interface type
+ */
+export type DefaultResourceInterface = {
+  [P in DefaultResourceFields]: string;
+};
+
+/**
+ * Extend user provided interface (T) with default resource fields
+ */
+export type ResourceInterface<T> = T & DefaultResourceInterface;
+
+/**
+ * Extract interface from the related resource either its array or a single type
+ * and expand it with the default resource fields
+ */
+export type FromRelated<T> = T extends any[] ? keyof ResourceInterface<T[number]> : keyof ResourceInterface<T>;

--- a/src/api/dataops/dataset.ts
+++ b/src/api/dataops/dataset.ts
@@ -4,25 +4,8 @@ import { DeleteQuery } from "../core/queries/deleteQuery";
 import { InsertQuery } from "../core/queries/insertQuery";
 import { SelectQuery } from "../core/queries/selectQuery";
 import { UpdateQuery } from "../core/queries/updateQuery";
-import { IResource, ResourceType } from "../core/resource";
+import { IResource, ResourceInterface, ResourceType } from "../core/resource";
 import { DataSetName } from "./dataops.tokens";
-
-/**
- * Default fields that will always exist for any dataset
- */
-export type DefaultDatasetFields = "id" | "created_at" | "updated_at";
-
-/**
- * Default dataset interface type
- */
-export type DefaultDatasetInterface = {
-  [P in DefaultDatasetFields]: string;
-};
-
-/**
- * Extend user provided interface (T) with default dataset fields
- */
-export type DatasetInterface<T> = T & DefaultDatasetInterface;
 
 /**
  * Dataset object used to fetch and modify data at your datasets.
@@ -50,7 +33,9 @@ export type DatasetInterface<T> = T & DefaultDatasetInterface;
  * @template T Generic type of your dataset, default to any
  */
 @Injectable()
-export class Dataset<T extends object = any, D extends DatasetInterface<T> = DatasetInterface<T>> implements IResource {
+export class Dataset<
+  T extends object = any,
+  D extends ResourceInterface<T> = ResourceInterface<T>> implements IResource {
   /**
    * Resource type of the dataset
    */

--- a/src/api/dataops/filteringApi.ts
+++ b/src/api/dataops/filteringApi.ts
@@ -1,5 +1,5 @@
 // tslint:disable:max-classes-per-file
-import { DatasetInterface } from "jexia-sdk-js/api/dataops/dataset";
+import { ResourceInterface } from "../core/resource";
 import { CompositeFilteringCondition, FilteringCondition, ICondition } from "./filteringCondition";
 
 /**
@@ -117,9 +117,9 @@ export interface IFilteringCriterion<T = any> {
  * @template T Generic type of your dataset, default to any
  * @template K Generic name of the dataset field you want to filter by
  */
-export function field<T = DatasetInterface<any>, K extends Extract<keyof DatasetInterface<T>, string> = any>(name: K):
-  FieldFilter<DatasetInterface<T>[K]> {
-  return new FieldFilter<DatasetInterface<T>[K]>(name);
+export function field<T = ResourceInterface<any>, K extends Extract<keyof ResourceInterface<T>, string> = any>(name: K):
+  FieldFilter<ResourceInterface<T>[K]> {
+  return new FieldFilter<ResourceInterface<T>[K]>(name);
 }
 
 /**

--- a/src/internal/query.spec.ts
+++ b/src/internal/query.spec.ts
@@ -20,25 +20,20 @@ describe("Query class", () => {
     direction: "desc",
     fields: ["field3"],
   };
-  let query1 = new Query();
-  let query2 = new Query();
 
   beforeEach(() => {
     query = new Query();
   });
 
   describe("should have initial attributes", () => {
-    it("undefined fields", () => {
-      expect(query.fields).toBeUndefined();
+    it("empty fields", () => {
+      expect(query.fields).toEqual([]);
     });
     it("undefined limit", () => {
       expect(query.limit).toBeUndefined();
     });
     it("undefined offset", () => {
       expect(query.offset).toBeUndefined();
-    });
-    it("empty relations array", () => {
-      expect((query as any).relations).toEqual([]);
     });
     it("undefined filtering conditions", () => {
       expect((query as any).filteringConditions).toBeUndefined();
@@ -67,19 +62,6 @@ describe("Query class", () => {
       query.addSortCondition(sort1.direction, ...sort1.fields);
       query.addSortCondition(sort2.direction, ...sort2.fields);
       expect((query as any).orders).toEqual([sort1, sort2]);
-    });
-  });
-
-  // TODO Develop relations
-  xdescribe("addRelation method", () => {
-    it("should push relation into an array", () => {
-      query.addRelation(query1);
-      expect((query as any).relations).toEqual([query1]);
-    });
-    it("should accumulate values", () => {
-      query.addRelation(query1);
-      query.addRelation(query2);
-      expect((query as any).relations).toEqual([query1, query2]);
     });
   });
 
@@ -154,18 +136,6 @@ describe("Query class", () => {
       query.addSortCondition(sort2.direction, ...sort2.fields);
       expect(query.compile()).toEqual({
         order: [sort1, sort2],
-      });
-    });
-
-    // TODO Develop relations
-    xit("relations option", () => {
-      query.addRelation(query1);
-      query.addRelation(query2);
-      expect(query.compile()).toEqual({
-        relations: {
-          "dataset1": query1.compile(),
-          "dataset2": query2.compile(),
-        },
       });
     });
   });

--- a/src/internal/query.ts
+++ b/src/internal/query.ts
@@ -43,13 +43,12 @@ export interface ICompiledQuery<T> {
 }
 
 export class Query<T = any> {
-  public fields: Array<KeyOfObject<T> | IAggField<T>>;
+  public fields: Array<KeyOfObject<T> | IAggField<T>> = [];
   public limit: number;
   public offset: number;
 
   private filteringConditions: ICondition;
   private orders: SortedFields<T> = [];
-  private relations: Query[] = [];
 
   /*
    * This method is here to encapsulate the translation of filter settings
@@ -65,10 +64,6 @@ export class Query<T = any> {
       throw new Error(MESSAGE.QUERY.MUST_PROVIDE_SORTING_FIELD);
     }
     this.orders.push({ fields, direction });
-  }
-
-  public addRelation(relation: Query): void {
-    this.relations.push(relation);
   }
 
   /* Collect all conditionals inside one object
@@ -94,7 +89,7 @@ export class Query<T = any> {
 
     /* Compile fields
      */
-    if (this.fields) {
+    if (this.fields.length) {
       compiledQueryOptions.outputs = this.fields.map(
         (field) => typeof field === "object" ? this.compileAggregation(field) : field
       );


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the new behavior?

Select query supports `related()` method which is able to populate nested fields (any level of nesting)

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

`relation()` method is not supported anymore

## Other information
