### PR TITLE
Fix attach/detach make filter required and change method to PUT 

### DIFF
--- a/spec/queryAction.ts
+++ b/spec/queryAction.ts
@@ -1,4 +1,0 @@
-import * as faker from "faker";
-import { QueryAction } from "../src/api/core/queries/baseQuery";
-
-export const getRandomQueryAction = (): QueryAction => faker.helpers.randomize(Object.values(QueryAction));

--- a/spec/requestMethod.ts
+++ b/spec/requestMethod.ts
@@ -1,0 +1,4 @@
+import * as faker from "faker";
+import { RequestMethod } from "../src/internal/requestAdapter.interfaces";
+
+export const getRandomRequestMethod = (): RequestMethod => faker.helpers.randomize(Object.values(RequestMethod));

--- a/spec/testUtils.ts
+++ b/spec/testUtils.ts
@@ -187,6 +187,6 @@ export const mockFileEvent = (id: string, action: EventSubscriptionType): RealTi
   data: [ { id }],
 });
 
-export * from "./queryAction";
+export * from "./requestMethod";
 export * from "./queryActionType";
 export * from "./filtering";

--- a/src/api/core/queries/actionQuery.ts
+++ b/src/api/core/queries/actionQuery.ts
@@ -1,8 +1,8 @@
 import { RequestExecuter } from "../../../internal/executer";
+import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
 import { QueryActionType } from "../../../internal/utils";
 import { IFilteringCriterion, IFilteringCriterionCallback } from "../../dataops/filteringApi";
 import { ResourceType } from "../resource";
-import { QueryAction } from "./baseQuery";
 import { FilterableQuery } from "./filterableQuery";
 
 /**
@@ -32,7 +32,7 @@ export class ActionQuery<T> extends FilterableQuery<T> {
     public readonly queryActionType: QueryActionType,
     filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
   ) {
-    super(queryExecuter, QueryAction.update, resourceType, resourceName);
+    super(queryExecuter, RequestMethod.PUT, resourceType, resourceName);
     this.query.setAction(queryActionType, actionResourceName, filter);
   }
 }

--- a/src/api/core/queries/actionQuery.ts
+++ b/src/api/core/queries/actionQuery.ts
@@ -30,7 +30,7 @@ export class ActionQuery<T> extends FilterableQuery<T> {
     resourceName: string,
     actionResourceName: string,
     public readonly queryActionType: QueryActionType,
-    filter?: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
+    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
   ) {
     super(queryExecuter, QueryAction.update, resourceType, resourceName);
     this.query.setAction(queryActionType, actionResourceName, filter);

--- a/src/api/core/queries/baseQuery.spec.ts
+++ b/src/api/core/queries/baseQuery.spec.ts
@@ -1,9 +1,10 @@
 import * as faker from "faker";
-import { createMockFor, getRandomQueryAction } from "../../../../spec/testUtils";
+import { createMockFor, getRandomRequestMethod } from "../../../../spec/testUtils";
 import { RequestExecuter } from "../../../internal/executer";
 import { IAggField } from "../../../internal/query";
+import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
 import { ResourceType } from "../resource";
-import { BaseQuery, QueryAction } from "./baseQuery";
+import { BaseQuery } from "./baseQuery";
 
 interface IUser {
   id: number;
@@ -13,10 +14,10 @@ interface IUser {
 
 const RESOURCE_NAME = faker.random.word();
 const RESOURCE_TYPE = faker.helpers.randomize([ResourceType.Dataset, ResourceType.Fileset]);
-const DEFAULT_ACTION = getRandomQueryAction();
+const DEFAULT_REQUEST_METHOD = getRandomRequestMethod();
 
 const createSubject = ({
-  action = DEFAULT_ACTION,
+  method = DEFAULT_REQUEST_METHOD,
   resourceName = RESOURCE_NAME,
   resourceType = RESOURCE_TYPE,
   requestExecuterMock = createMockFor(RequestExecuter),
@@ -24,12 +25,12 @@ const createSubject = ({
   // Declare child class as long as BaseQuery class is abstract
   class BaseQueryChild<T> extends BaseQuery<T> {
     protected readonly body = null;
-    constructor(r: RequestExecuter, a: QueryAction, t: ResourceType, d: string) {
-      super(r, a, t, d);
+    constructor(r: RequestExecuter, m: RequestMethod, t: ResourceType, d: string) {
+      super(r, m, t, d);
     }
   }
 
-  const subject = new BaseQueryChild<IUser>(requestExecuterMock, action, resourceType, resourceName);
+  const subject = new BaseQueryChild<IUser>(requestExecuterMock, method, resourceType, resourceName);
 
   return {
     resourceName,
@@ -50,8 +51,8 @@ describe("BaseQuery class", () => {
     expect((subject as any).queryExecuter).toBeDefined();
   });
 
-  it("action should equal passed action", () => {
-    expect((subject as any).action).toEqual(DEFAULT_ACTION);
+  it("should contain passed action", () => {
+    expect((subject as any).method).toEqual(DEFAULT_REQUEST_METHOD);
   });
 
   it("Query should be defined", () => {
@@ -129,7 +130,7 @@ describe("compiledRequest method", () => {
   });
 
   it("should contain correct action key", () => {
-    expect(subject.compiledRequest.action).toEqual(DEFAULT_ACTION);
+    expect(subject.compiledRequest.method).toEqual(DEFAULT_REQUEST_METHOD);
   });
 
   it("should contain empty body by default", () => {

--- a/src/api/core/queries/baseQuery.ts
+++ b/src/api/core/queries/baseQuery.ts
@@ -1,17 +1,8 @@
 import { RequestExecuter } from "../../../internal/executer";
 import { IRequestExecuterData } from "../../../internal/executer.interfaces";
 import { IAggField, Query } from "../../../internal/query";
+import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
 import { ResourceType } from "../resource";
-
-/**
- * @internal
- */
-export enum QueryAction {
-  select = "select",
-  insert = "insert",
-  update = "update",
-  delete = "delete",
-}
 
 /**
  * Base class for SELECT, INSERT, UPDATE and DELETE queries. Implements fields to be returned
@@ -35,7 +26,7 @@ export abstract class BaseQuery<T> {
 
   protected constructor(
       protected queryExecuter: RequestExecuter,
-      protected readonly action: QueryAction,
+      protected readonly method: RequestMethod,
       protected readonly resourceType: ResourceType,
       protected readonly resourceName: string,
   ) {
@@ -64,7 +55,7 @@ export abstract class BaseQuery<T> {
     return {
       resourceType: this.resourceType,
       resourceName: this.resourceName,
-      action: this.action,
+      method: this.method,
       body: this.body || {},
       queryParams: this.query.compileToQueryParams() || [],
     };

--- a/src/api/core/queries/deleteQuery.spec.ts
+++ b/src/api/core/queries/deleteQuery.spec.ts
@@ -1,8 +1,8 @@
 import * as faker from "faker";
 import { createMockFor } from "../../../../spec/testUtils";
 import { RequestExecuter } from "../../../internal/executer";
+import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
 import { ResourceType } from "../resource";
-import { QueryAction } from "./baseQuery";
 import { DeleteQuery } from "./deleteQuery";
 
 const createSubject = ({
@@ -33,6 +33,6 @@ describe("DeleteQuery class", () => {
 
   it("should contain delete as request", () => {
     const { subject } = createSubject();
-    expect((subject as any).action).toBe(QueryAction.delete);
+    expect((subject as any).method).toBe(RequestMethod.DELETE);
   });
 });

--- a/src/api/core/queries/deleteQuery.ts
+++ b/src/api/core/queries/deleteQuery.ts
@@ -1,6 +1,6 @@
 import { RequestExecuter } from "../../../internal/executer";
+import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
 import { ResourceType } from "../resource";
-import { QueryAction } from "./baseQuery";
 import { FilterableQuery } from "./filterableQuery";
 
 /**
@@ -24,6 +24,6 @@ export class DeleteQuery<T> extends FilterableQuery<T> {
    * @internal
    */
   public constructor(queryExecuter: RequestExecuter, resourceType: ResourceType, resourceName: string) {
-    super(queryExecuter, QueryAction.delete, resourceType, resourceName);
+    super(queryExecuter, RequestMethod.DELETE, resourceType, resourceName);
   }
 }

--- a/src/api/core/queries/filterableQuery.spec.ts
+++ b/src/api/core/queries/filterableQuery.spec.ts
@@ -2,9 +2,9 @@ import * as faker from "faker";
 import { createMockFor } from "../../../../spec/testUtils";
 import { RequestExecuter } from "../../../internal/executer";
 import { Query } from "../../../internal/query";
+import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
 import { field } from "../../dataops/filteringApi";
 import { ResourceType } from "../resource";
-import { QueryAction } from "./baseQuery";
 import { FilterableQuery } from "./filterableQuery";
 
 interface IUser {
@@ -13,7 +13,7 @@ interface IUser {
 }
 
 let createSubject = ({
-  action = QueryAction.select,
+  method = RequestMethod.GET,
   resourceName = faker.random.word(),
   resourceType = faker.helpers.randomize([ResourceType.Dataset, ResourceType.Fileset]),
   requestExecuterMock = createMockFor(RequestExecuter),
@@ -21,12 +21,12 @@ let createSubject = ({
 } = {}) => {
   // Declare child class as long as FilterableQuery is abstract
   class FilterableQueryChild<T> extends FilterableQuery<T> {
-    constructor(r: RequestExecuter, a: QueryAction, t: ResourceType, d: string) {
-      super(r, a, t, d);
+    constructor(r: RequestExecuter, m: RequestMethod, t: ResourceType, d: string) {
+      super(r, m, t, d);
     }
   }
 
-  const subject = new FilterableQueryChild<IUser>(requestExecuterMock, action, resourceType, resourceName);
+  const subject = new FilterableQueryChild<IUser>(requestExecuterMock, method, resourceType, resourceName);
   let queryMock = createMockForQuery ? createMockFor<Query>(Query) : new Query();
 
   // tslint:disable-next-line:no-string-literal

--- a/src/api/core/queries/insertQuery.spec.ts
+++ b/src/api/core/queries/insertQuery.spec.ts
@@ -1,5 +1,6 @@
 import * as faker from "faker";
 import { createRequestExecuterMock } from "../../../../spec/testUtils";
+import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
 import { ResourceType } from "../resource";
 import { InsertQuery } from "./insertQuery";
 
@@ -25,17 +26,11 @@ describe("InsertQuery class", () => {
     });
   });
 
-  describe("when instantiating a insertQuery object from client", () => {
-    it("should be able to invoke methods exposed by it", () => {
-      expect(typeof subject.execute).toBe("function");
-    });
-  });
-
   it("should execute the query with the correct parameters", () => {
     spyOn(qe, "executeRequest");
     subject.execute();
     expect(qe.executeRequest).toHaveBeenLastCalledWith({
-      action: (subject as any).action,
+      method: RequestMethod.POST,
       body: [fakeRecord],
       resourceType,
       resourceName

--- a/src/api/core/queries/insertQuery.ts
+++ b/src/api/core/queries/insertQuery.ts
@@ -1,6 +1,7 @@
 import { RequestExecuter } from "../../../internal/executer";
+import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
 import { ResourceType } from "../resource";
-import { BaseQuery, QueryAction } from "./baseQuery";
+import { BaseQuery } from "./baseQuery";
 
 /**
  * Query object specialized for insert statements.
@@ -29,7 +30,7 @@ export class InsertQuery<T, D extends T> extends BaseQuery<T> {
    * @internal
    */
   public constructor(queryExecuter: RequestExecuter, records: T[], resourceType: ResourceType, resourceName: string) {
-    super(queryExecuter, QueryAction.insert, resourceType, resourceName);
+    super(queryExecuter, RequestMethod.POST, resourceType, resourceName);
     this.body = records;
   }
 
@@ -41,7 +42,7 @@ export class InsertQuery<T, D extends T> extends BaseQuery<T> {
     return this.queryExecuter.executeRequest({
       resourceType: this.resourceType,
       resourceName: this.resourceName,
-      action: this.action,
+      method: this.method,
       body: this.body,
     });
   }

--- a/src/api/core/queries/selectQuery.ts
+++ b/src/api/core/queries/selectQuery.ts
@@ -1,7 +1,7 @@
 import { MESSAGE } from "../../../config/message";
 import { RequestExecuter } from "../../../internal/executer";
+import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
 import { FromRelated, ResourceType } from "../resource";
-import { QueryAction } from "./baseQuery";
 import { FilterableQuery } from "./filterableQuery";
 import { RelatedQuery } from "./relatedQuery";
 
@@ -25,7 +25,7 @@ export class SelectQuery<T> extends FilterableQuery<T> {
    * @internal
    */
   public constructor(queryExecuter: RequestExecuter, resourceType: ResourceType, resourceName: string) {
-    super(queryExecuter, QueryAction.select, resourceType, resourceName);
+    super(queryExecuter, RequestMethod.GET, resourceType, resourceName);
   }
 
   /**

--- a/src/api/core/queries/updateQuery.ts
+++ b/src/api/core/queries/updateQuery.ts
@@ -1,6 +1,6 @@
 import { RequestExecuter } from "../../../internal/executer";
+import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
 import { ResourceType } from "../resource";
-import { QueryAction } from "./baseQuery";
 import { FilterableQuery } from "./filterableQuery";
 
 /**
@@ -30,7 +30,7 @@ export class UpdateQuery<T> extends FilterableQuery<T> {
    * @internal
    */
   public constructor(queryExecuter: RequestExecuter, data: T, resourceType: ResourceType, resourceName: string) {
-    super(queryExecuter, QueryAction.update, resourceType, resourceName);
+    super(queryExecuter, RequestMethod.PATCH, resourceType, resourceName);
     this.body = data;
   }
 

--- a/src/api/core/tokenManager.spec.ts
+++ b/src/api/core/tokenManager.spec.ts
@@ -1,7 +1,7 @@
 import * as faker from "faker";
 import { createMockFor } from "../../../spec/testUtils";
 import { MESSAGE } from "../../config";
-import { Methods, RequestAdapter } from "../../internal/requestAdapter";
+import { RequestAdapter, RequestMethod } from "../../internal/requestAdapter";
 import { Logger } from "../logger/logger";
 import { TokenManager, Tokens } from "./tokenManager";
 
@@ -64,7 +64,7 @@ describe("TokenManager", () => {
         expect.any(String), // url does not matter
         {
           body: { method: "apk", key: validOptions.key, secret: validOptions.secret },
-          method: Methods.POST,
+          method: RequestMethod.POST,
         },
       );
     });
@@ -265,7 +265,7 @@ describe("TokenManager", () => {
         (subject as any).refreshUrl,
         {
           body: { refresh_token: tokens.refresh_token },
-          method: Methods.POST
+          method: RequestMethod.POST
         },
       );
     });

--- a/src/api/core/tokenManager.ts
+++ b/src/api/core/tokenManager.ts
@@ -1,6 +1,6 @@
 import { Injectable, InjectionToken } from "injection-js";
 import { API, DELAY, MESSAGE } from "../../config";
-import { Methods, RequestAdapter } from "../../internal/requestAdapter";
+import { RequestAdapter, RequestMethod } from "../../internal/requestAdapter";
 import { Logger } from "../logger/logger";
 import { TokenStorage } from "./componentStorage";
 
@@ -215,7 +215,7 @@ export class TokenManager {
     return this.requestAdapter
       .execute(url, {
         body,
-        method: Methods.POST
+        method: RequestMethod.POST,
       })
       .then((refreshedTokens: Tokens) => {
         defers.resolve(refreshedTokens.access_token);

--- a/src/api/dataops/dataset.spec.ts
+++ b/src/api/dataops/dataset.spec.ts
@@ -61,53 +61,41 @@ describe("Dataset class", () => {
   });
 
   describe("On attach", () => {
-    it("should return the query by passing a filter", () => {
+    let query: any;
+
+    beforeEach(() => {
       const dataset = new Dataset("test", createMockFor(RequestExecuter));
-      const query = dataset.attach(
+      query = dataset.attach(
         faker.random.word(),
         getRandomFilteringCriteria(),
       );
+    });
 
+    it("should return the query", () => {
       expect(query instanceof ActionQuery).toBeTruthy();
     });
 
-    it("should return the query without passing a filter", () => {
-      const dataset = new Dataset("test", createMockFor(RequestExecuter));
-      const query = dataset.attach(faker.random.word());
-
-      expect(query instanceof ActionQuery).toBeTruthy();
-    });
-
-    it("should return the query without passing a filter", () => {
-      const dataset = new Dataset("test", createMockFor(RequestExecuter));
-      const query = dataset.attach(faker.random.word());
-
+    it("should pass the correct query action type", () => {
       expect(query.queryActionType).toBe(QueryActionType.ATTACH);
     });
   });
 
   describe("On detach", () => {
-    it("should return the query by passing a filter", () => {
+    let query: any;
+
+    beforeEach(() => {
       const dataset = new Dataset("test", createMockFor(RequestExecuter));
-      const query = dataset.detach(
+      query = dataset.detach(
         faker.random.word(),
         getRandomFilteringCriteria(),
       );
-
-      expect(query instanceof ActionQuery).toBeTruthy();
     });
 
-    it("should return the query without passing a filter", () => {
-      const dataset = new Dataset("test", createMockFor(RequestExecuter));
-      const query = dataset.detach(faker.random.word());
-
+    it("should return the query", () => {
       expect(query instanceof ActionQuery).toBeTruthy();
     });
 
     it("should pass the correct query action type", () => {
-      const dataset = new Dataset("test", createMockFor(RequestExecuter));
-      const query = dataset.detach(faker.random.word());
-
       expect(query.queryActionType).toBe(QueryActionType.DETACH);
     });
   });

--- a/src/api/dataops/dataset.ts
+++ b/src/api/dataops/dataset.ts
@@ -114,7 +114,7 @@ export class Dataset<
    */
   public attach(
     resourceName: string,
-    filter?: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
+    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
   ): ActionQuery<T> {
     return new ActionQuery(
       this.requestExecuter,
@@ -135,7 +135,7 @@ export class Dataset<
    */
   public detach(
     resourceName: string,
-    filter?: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
+    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
   ): ActionQuery<T> {
     return new ActionQuery(
       this.requestExecuter,

--- a/src/api/fileops/fileset.spec.ts
+++ b/src/api/fileops/fileset.spec.ts
@@ -242,53 +242,41 @@ describe("Fileset", () => {
   });
 
   describe("On attach", () => {
-    it("should return the query by passing a filter", () => {
+    let query: any;
+
+    beforeEach(() => {
       const { subject } = createSubject();
-      const query = subject.attach(
+      query = subject.attach(
         faker.random.word(),
         getRandomFilteringCriteria(),
       );
-
-      expect(query instanceof ActionQuery).toBeTruthy();
     });
 
-    it("should return the query without passing a filter", () => {
-      const { subject } = createSubject();
-      const query = subject.attach(faker.random.word());
-
+    it("should return the query", () => {
       expect(query instanceof ActionQuery).toBeTruthy();
     });
 
     it("should pass the correct query action type", () => {
-      const { subject } = createSubject();
-      const query = subject.attach(faker.random.word());
-
       expect(query.queryActionType).toBe(QueryActionType.ATTACH);
     });
   });
 
   describe("On detach", () => {
-    it("should return the query by passing a filter", () => {
+    let query: any;
+
+    beforeEach(() => {
       const { subject } = createSubject();
-      const query = subject.detach(
+      query = subject.detach(
         faker.random.word(),
         getRandomFilteringCriteria(),
       );
-
-      expect(query instanceof ActionQuery).toBeTruthy();
     });
 
-    it("should return the query without passing a filter", () => {
-      const { subject } = createSubject();
-      const query = subject.detach(faker.random.word());
-
+    it("should return the query", () => {
       expect(query instanceof ActionQuery).toBeTruthy();
     });
 
     it("should pass the correct query action type", () => {
-      const { subject } = createSubject();
-      const query = subject.detach(faker.random.word());
-
       expect(query.queryActionType).toBe(QueryActionType.DETACH);
     });
   });

--- a/src/api/fileops/fileset.ts
+++ b/src/api/fileops/fileset.ts
@@ -111,7 +111,7 @@ export class Fileset<FormDataType extends IFormData<F>, T, D, F> implements IRes
    */
   public attach(
     resourceName: string,
-    filter?: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
+    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
   ): ActionQuery<T> {
     return new ActionQuery(
       this.requestExecuter,
@@ -132,7 +132,7 @@ export class Fileset<FormDataType extends IFormData<F>, T, D, F> implements IRes
    */
   public detach(
     resourceName: string,
-    filter?: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
+    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
   ): ActionQuery<T> {
     return new ActionQuery(
       this.requestExecuter,

--- a/src/api/ums/umsModule.spec.ts
+++ b/src/api/ums/umsModule.spec.ts
@@ -3,7 +3,7 @@ import * as faker from "faker";
 import { ReflectiveInjector } from "injection-js";
 import { createMockFor, SpyObj } from "../../../spec/testUtils";
 import { API } from "../../config";
-import { Methods, RequestAdapter } from "../../internal/requestAdapter";
+import { RequestAdapter, RequestMethod } from "../../internal/requestAdapter";
 import { deferPromise } from "../../internal/utils";
 import { Client } from "../core/client";
 import { AuthOptions, TokenManager } from "../core/tokenManager";
@@ -205,7 +205,7 @@ describe("UMS Module", () => {
               new_password: newPassword,
             },
             headers: { Authorization: `Bearer ${tokenTest}`},
-            method: Methods.POST,
+            method: RequestMethod.POST,
           },
         );
       });
@@ -231,7 +231,7 @@ describe("UMS Module", () => {
           {
             body: { password: testUser.password },
             headers: { Authorization: `Bearer ${tokenTest}`},
-            method: Methods.DELETE,
+            method: RequestMethod.DELETE,
           },
         );
       });

--- a/src/api/ums/umsModule.ts
+++ b/src/api/ums/umsModule.ts
@@ -1,6 +1,6 @@
 import { ReflectiveInjector } from "injection-js";
 import { API } from "../../config";
-import { Methods, RequestAdapter } from "../../internal/requestAdapter";
+import { RequestAdapter, RequestMethod } from "../../internal/requestAdapter";
 import { IModule, ModuleConfiguration } from "../core/module";
 import { AuthOptions, TokenManager, Tokens } from "../core/tokenManager";
 
@@ -58,7 +58,7 @@ export class UMSModule implements IModule {
 
     return this.requestAdapter.execute<Tokens>(
       this.getUrl(API.AUTH, false),
-      { body, method: Methods.POST }
+      { body, method: RequestMethod.POST }
     ).then((tokens) => {
 
       this.tokenManager.addTokens(
@@ -82,7 +82,7 @@ export class UMSModule implements IModule {
     };
     return this.requestAdapter.execute<IUMSUser>(
       this.getUrl(API.UMS.SIGNUP),
-      { body, method: Methods.POST },
+      { body, method: RequestMethod.POST },
     );
   }
 
@@ -120,7 +120,7 @@ export class UMSModule implements IModule {
     return this.tokenManager.token(alias)
       .then((token) => this.requestAdapter.execute<IUMSUser>(
         this.getUrl(API.UMS.CHANGEPASSWORD),
-        { body, headers: { Authorization: `Bearer ${token}` }, method: Methods.POST },
+        { body, headers: { Authorization: `Bearer ${token}` }, method: RequestMethod.POST },
       ));
   }
 
@@ -134,7 +134,7 @@ export class UMSModule implements IModule {
     return this.tokenManager.token(alias)
       .then((token) => this.requestAdapter.execute(
         this.getUrl(API.UMS.USER),
-        { body, headers: { Authorization: `Bearer ${token}` }, method: Methods.DELETE },
+        { body, headers: { Authorization: `Bearer ${token}` }, method: RequestMethod.DELETE },
       ));
   }
 

--- a/src/internal/executer.interfaces.ts
+++ b/src/internal/executer.interfaces.ts
@@ -1,11 +1,11 @@
-import { QueryAction } from "../api/core/queries/baseQuery";
 import { ResourceType } from "../api/core/resource";
+import { RequestMethod } from "./requestAdapter.interfaces";
 import { QueryParam } from "./utils";
 
 export interface IRequestExecuterData {
   resourceType: ResourceType;
   resourceName: string;
-  action: QueryAction;
+  method: RequestMethod;
   body?: any;
   queryParams?: QueryParam[];
 }

--- a/src/internal/executer.ts
+++ b/src/internal/executer.ts
@@ -1,12 +1,11 @@
 import { Inject, Injectable } from "injection-js";
 import { ClientInit } from "../api/core/client";
-import { QueryAction } from "../api/core/queries/baseQuery";
 import { ResourceType } from "../api/core/resource";
 import { AuthOptions, IAuthOptions, TokenManager } from "../api/core/tokenManager";
 import { API } from "../config";
 import { QueryParam } from "../internal/utils";
 import { IRequestExecuterData } from "./executer.interfaces";
-import { IRequestOptions, Methods, RequestAdapter } from "./requestAdapter";
+import { IRequestOptions, RequestAdapter, RequestMethod } from "./requestAdapter";
 
 @Injectable()
 export class RequestExecuter {
@@ -26,22 +25,12 @@ export class RequestExecuter {
     return this.requestAdapter.execute(URI, options);
   }
 
-  public getMethod(action: QueryAction): Methods {
-    switch (action) {
-      default:
-      case QueryAction.insert: return Methods.POST;
-      case QueryAction.delete: return Methods.DELETE;
-      case QueryAction.select: return Methods.GET;
-      case QueryAction.update: return Methods.PATCH;
-    }
-  }
-
   private async getRequestOptions(request: IRequestExecuterData): Promise<IRequestOptions> {
     const token = await this.tokenManager.token(this.config.auth);
 
     const options: IRequestOptions = {
       headers: { Authorization: `Bearer ${token}` },
-      method: this.getMethod(request.action)
+      method: request.method,
     };
 
     if (this.hasBody(request)) {
@@ -51,8 +40,8 @@ export class RequestExecuter {
     return options;
   }
 
-  private hasBody({ action }: IRequestExecuterData): boolean {
-    return ![Methods.GET, Methods.DELETE].includes(this.getMethod(action));
+  private hasBody({ method }: IRequestExecuterData): boolean {
+    return ![RequestMethod.GET, RequestMethod.DELETE].includes(method);
   }
 
   /**

--- a/src/internal/requestAdapter.interfaces.ts
+++ b/src/internal/requestAdapter.interfaces.ts
@@ -1,0 +1,26 @@
+/* List of allowed methods */
+export enum RequestMethod {
+  GET = "GET",
+  POST = "POST",
+  PUT = "PUT",
+  PATCH = "PATCH",
+  DELETE = "DELETE",
+  OPTIONS = "OPTIONS",
+}
+
+export interface IRequestOptions extends RequestInit {
+  body?: any;
+}
+
+export interface IHTTPResponse {
+  ok: boolean;
+  status: number;
+  statusText: string;
+  json(): Promise<any>;
+}
+
+export interface IRequestAdapter {
+  execute(uri: string, opt: IRequestOptions): Promise<any>;
+}
+
+export type Fetch = (url: string, init?: IRequestOptions) => Promise<IHTTPResponse>;

--- a/src/internal/requestAdapter.spec.ts
+++ b/src/internal/requestAdapter.spec.ts
@@ -1,31 +1,6 @@
 // tslint:disable:max-line-length
 import { MESSAGE } from "../config";
-import { IHTTPResponse, IRequestAdapter, IRequestOptions, Methods, RequestAdapter } from "./requestAdapter";
-
-/* Mock request adapter */
-export const mockRequestAdapter: IRequestAdapter = {
-  execute: (uri: string, opt: IRequestOptions): Promise<any> => {
-    switch (opt.method) {
-      /* log in */
-      case Methods.POST:
-        if ((opt.body as any).email === "validKey" && (opt.body as any).password === "validSecret") {
-          return Promise.resolve({ token: "validToken", refresh_token: "validRefreshToken" });
-        }
-        return Promise.reject(new Error("Auth error."));
-      /* refresh token */
-      case Methods.PATCH:
-        if ((opt.headers as any).Authorization === "validToken"
-          && (opt.body as any).refresh_token === "validRefreshToken") {
-          return Promise.resolve({ token: "updatedToken", refresh_token: "updatedRefreshToken" });
-        }
-        return Promise.reject(new Error("Auth error."));
-      /* do not allow to use other methods */
-      default:
-        /* not implemented */
-        return Promise.reject(new Error("Not implemented."));
-    }
-  },
-};
+import { IHTTPResponse, IRequestOptions, RequestAdapter } from "./requestAdapter";
 
 describe("Class: RequestAdapter", () => {
   describe("when creating the RequestAdapter", () => {

--- a/src/internal/requestAdapter.ts
+++ b/src/internal/requestAdapter.ts
@@ -1,26 +1,6 @@
 import { Logger } from "../api/logger/logger";
 import { MESSAGE } from "../config";
-
-/* List of allowed methods */
-export enum Methods {
-  GET = "GET",
-  POST = "POST",
-  PUT = "PUT",
-  PATCH = "PATCH",
-  DELETE = "DELETE",
-  OPTIONS = "OPTIONS",
-}
-
-export interface IRequestOptions extends RequestInit {
-  body?: any;
-}
-
-export interface IHTTPResponse {
-  ok: boolean;
-  status: number;
-  statusText: string;
-  json(): Promise<any>;
-}
+import { Fetch, IHTTPResponse, IRequestAdapter, IRequestOptions, RequestMethod } from "./requestAdapter.interfaces";
 
 function status(response: IHTTPResponse): Promise<IHTTPResponse> {
   if (!response.ok) {
@@ -33,13 +13,6 @@ function json(response: IHTTPResponse): Promise<any> {
   /* convert response to JSON */
   return response.json();
 }
-
-export interface IRequestAdapter {
-  execute(uri: string, opt: IRequestOptions): Promise<any>;
-}
-
-export type Fetch = (url: string, init?: IRequestOptions) => Promise<IHTTPResponse>;
-
 export class RequestAdapter implements IRequestAdapter {
 
   private logger: Logger = new Logger();
@@ -72,7 +45,7 @@ export class RequestAdapter implements IRequestAdapter {
    */
   public upload<T = any>(uri: string, headers: {[header: string]: string}, body: any): Promise<T> {
     let logMessage = `(REQUEST) UPLOAD ${uri}\n`;
-    return this.fetch(uri, { body, headers, method: Methods.POST })
+    return this.fetch(uri, { body, headers, method: RequestMethod.POST })
       .then((response) => {
         logMessage += `(RESPONSE) ${response.status} ${response.statusText}`;
         this.logger.debug("RequestAdapter", logMessage);
@@ -84,3 +57,5 @@ export class RequestAdapter implements IRequestAdapter {
       .then(json);
   }
 }
+
+export * from "./requestAdapter.interfaces";


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Attach/detach filter param is optional in sdk, but required in the API. The request verb accepted is `PUT` while sdk is sending `PATCH`

Issue Number: N/A

## What is the new behavior?
Make param required and change method to `PUT`

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
