### PR TITLE
Fix attach/detach parsing empty response

### DIFF
--- a/spec/resource.ts
+++ b/spec/resource.ts
@@ -1,0 +1,4 @@
+import * as faker from "faker";
+import { ResourceType } from "../src/api/core/resource";
+
+export const getRandomResourceType = (): ResourceType => faker.helpers.randomize(Object.values(ResourceType));

--- a/spec/testUtils.ts
+++ b/spec/testUtils.ts
@@ -159,10 +159,12 @@ export const validClientOpts = {
 
 export const fetchWithRequestMockOk = (uri: string, opts?: IRequestOptions): Promise<IHTTPResponse> => {
   return Promise.resolve({
-    json: () => Promise.resolve({
+    text: () => Promise.resolve(JSON.stringify({
       access_token: "access_token",
       refresh_token: "refresh_token"
-    }), ok: true, status: 200,
+    })),
+    ok: true,
+    status: 200,
   } as IHTTPResponse);
 };
 
@@ -188,5 +190,6 @@ export const mockFileEvent = (id: string, action: EventSubscriptionType): RealTi
 });
 
 export * from "./requestMethod";
+export * from "./resource";
 export * from "./queryActionType";
 export * from "./filtering";

--- a/src/api/core/queries/actionQuery.spec.ts
+++ b/src/api/core/queries/actionQuery.spec.ts
@@ -3,10 +3,10 @@ import {
   createRequestExecuterMock,
   getRandomFilteringCriteria,
   getRandomQueryActionType,
+  getRandomResourceType,
 } from "../../../../spec/testUtils";
 import { toQueryParams } from "../../../internal/utils";
 import { toFilteringCriterion } from "../../dataops/filteringApi";
-import { ResourceType } from "../resource";
 import { ActionQuery } from "./actionQuery";
 
 describe("ActionQuery class", () => {
@@ -18,7 +18,7 @@ describe("ActionQuery class", () => {
   } = {}) {
     const subject = new ActionQuery(
       requestExecuterMock,
-      faker.helpers.randomize([ResourceType.Dataset, ResourceType.Fileset]),
+      getRandomResourceType(),
       faker.random.word(),
       actionResourceName,
       queryActionType,

--- a/src/api/core/queries/baseQuery.spec.ts
+++ b/src/api/core/queries/baseQuery.spec.ts
@@ -1,5 +1,5 @@
 import * as faker from "faker";
-import { createMockFor, getRandomRequestMethod } from "../../../../spec/testUtils";
+import { createMockFor, getRandomRequestMethod, getRandomResourceType } from "../../../../spec/testUtils";
 import { RequestExecuter } from "../../../internal/executer";
 import { IAggField } from "../../../internal/query";
 import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
@@ -13,7 +13,7 @@ interface IUser {
 }
 
 const RESOURCE_NAME = faker.random.word();
-const RESOURCE_TYPE = faker.helpers.randomize([ResourceType.Dataset, ResourceType.Fileset]);
+const RESOURCE_TYPE = getRandomResourceType();
 const DEFAULT_REQUEST_METHOD = getRandomRequestMethod();
 
 const createSubject = ({

--- a/src/api/core/queries/deleteQuery.spec.ts
+++ b/src/api/core/queries/deleteQuery.spec.ts
@@ -1,13 +1,12 @@
 import * as faker from "faker";
-import { createMockFor } from "../../../../spec/testUtils";
+import { createMockFor, getRandomResourceType } from "../../../../spec/testUtils";
 import { RequestExecuter } from "../../../internal/executer";
 import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
-import { ResourceType } from "../resource";
 import { DeleteQuery } from "./deleteQuery";
 
 const createSubject = ({
   resourceName = faker.random.word(),
-  resourceType = faker.helpers.randomize([ResourceType.Dataset, ResourceType.Fileset]),
+  resourceType = getRandomResourceType(),
   requestExecuterMock = createMockFor(RequestExecuter),
 } = {}) => {
   const subject = new DeleteQuery(requestExecuterMock, resourceType, resourceName);

--- a/src/api/core/queries/filterableQuery.spec.ts
+++ b/src/api/core/queries/filterableQuery.spec.ts
@@ -1,5 +1,5 @@
 import * as faker from "faker";
-import { createMockFor } from "../../../../spec/testUtils";
+import { createMockFor, getRandomResourceType } from "../../../../spec/testUtils";
 import { RequestExecuter } from "../../../internal/executer";
 import { Query } from "../../../internal/query";
 import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
@@ -15,7 +15,7 @@ interface IUser {
 let createSubject = ({
   method = RequestMethod.GET,
   resourceName = faker.random.word(),
-  resourceType = faker.helpers.randomize([ResourceType.Dataset, ResourceType.Fileset]),
+  resourceType = getRandomResourceType(),
   requestExecuterMock = createMockFor(RequestExecuter),
   createMockForQuery = true,
 } = {}) => {

--- a/src/api/core/queries/insertQuery.spec.ts
+++ b/src/api/core/queries/insertQuery.spec.ts
@@ -1,12 +1,11 @@
 import * as faker from "faker";
-import { createRequestExecuterMock } from "../../../../spec/testUtils";
+import { createRequestExecuterMock, getRandomResourceType } from "../../../../spec/testUtils";
 import { RequestMethod } from "../../../internal/requestAdapter.interfaces";
-import { ResourceType } from "../resource";
 import { InsertQuery } from "./insertQuery";
 
 describe("InsertQuery class", () => {
   const resourceName = faker.random.word();
-  const resourceType = faker.helpers.randomize([ResourceType.Dataset, ResourceType.Fileset]);
+  const resourceType = getRandomResourceType();
   let qe: any;
   let subject: InsertQuery<any, any>;
 

--- a/src/api/core/queries/selectQuery.spec.ts
+++ b/src/api/core/queries/selectQuery.spec.ts
@@ -1,11 +1,10 @@
 // tslint:disable:no-string-literal
 import * as faker from "faker";
 // tslint:disable:one-variable-per-declaration
-import { createMockFor } from "../../../../spec/testUtils";
+import { createMockFor, getRandomResourceType } from "../../../../spec/testUtils";
 import { MESSAGE } from "../../../config";
 import { RequestExecuter } from "../../../internal/executer";
 import { Query } from "../../../internal/query";
-import { ResourceType } from "../resource";
 import { SelectQuery } from "./selectQuery";
 
 describe("SelectQuery class", () => {
@@ -13,7 +12,7 @@ describe("SelectQuery class", () => {
 
   function createSubject({
     resourceName = faker.random.word(),
-    resourceType = faker.helpers.randomize([ResourceType.Dataset, ResourceType.Fileset]),
+    resourceType = getRandomResourceType(),
     mockQuery = true,
     requestExecuterMock = createMockFor(RequestExecuter),
   } = {}) {

--- a/src/api/core/queries/updateQuery.spec.ts
+++ b/src/api/core/queries/updateQuery.spec.ts
@@ -1,13 +1,12 @@
 // tslint:disable:no-string-literal
 import * as faker from "faker";
-import { createMockFor, createRequestExecuterMock, SpyObj } from "../../../../spec/testUtils";
+import { createMockFor, createRequestExecuterMock, getRandomResourceType, SpyObj } from "../../../../spec/testUtils";
 import { RequestExecuter } from "../../../internal/executer";
-import { ResourceType } from "../resource";
 import { UpdateQuery } from "./updateQuery";
 
 const createSubject = ({
   resourceName = faker.random.word(),
-  resourceType = faker.helpers.randomize([ResourceType.Dataset, ResourceType.Fileset]),
+  resourceType = getRandomResourceType(),
   data = {},
   requestExecuterMock = createMockFor(RequestExecuter),
 } = {}) => {

--- a/src/internal/requestAdapter.interfaces.ts
+++ b/src/internal/requestAdapter.interfaces.ts
@@ -16,7 +16,7 @@ export interface IHTTPResponse {
   ok: boolean;
   status: number;
   statusText: string;
-  json(): Promise<any>;
+  text(): Promise<string>;
 }
 
 export interface IRequestAdapter {

--- a/src/internal/requestAdapter.ts
+++ b/src/internal/requestAdapter.ts
@@ -10,8 +10,8 @@ function status(response: IHTTPResponse): Promise<IHTTPResponse> {
 }
 
 function json(response: IHTTPResponse): Promise<any> {
-  /* convert response to JSON */
-  return response.json();
+  // parses response body into JSON or return an empty object when it's empty
+  return response.text().then((text) => text ? JSON.parse(text) : {});
 }
 export class RequestAdapter implements IRequestAdapter {
 


### PR DESCRIPTION
## PR Checklist

This PR is dependant on https://github.com/jexia/jexia-sdk-js/pull/101

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Attach/detach request is calling `response.json()` but the response is empty (so, not a valid json) so an error is thrown

Issue Number: N/A

## What is the new behavior?
Introduced a new parameter for `RequestAdatpter:execute()` to ignore the response and return an empty object instead.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
