### PR TITLE
Allow attach/detach to receive array of objects/ids as filter

### DIFF
--- a/extra_docs/relations/README.md
+++ b/extra_docs/relations/README.md
@@ -208,9 +208,50 @@ Then some comments...
   //   { id: ..., text: "Might've been waaaay better", like: false }
   // ]
 ```
+<br/>
 
 Finally, you want to relate these with your post, so you call `.attach()` passing the name of the **resource** (that can
-be either a **dataset** or a **fileset**) and filter criteria:
+be either a **dataset** or a **fileset**) and a second argument, a filter that will restrict the operation.
+
+Available ways to filter attach/detach operation:
+
+```typescript
+  // an array of entities containing their id
+  dom.dataset("posts")
+    .attach("comments", [
+      {
+        id: "b4961b6a-85a2-4ee8-b946-9001c978c801",
+        text: "Very nice, congrats!",
+      },
+      {
+        id: "e199d460-c88f-4ab9-8373-1d6ad0bd0acb",
+        text: "Might've been waaaay better",
+      },
+    ]);
+
+  // an array of ids
+  dom.dataset("posts")
+    .attach("comments", [
+      "b4961b6a-85a2-4ee8-b946-9001c978c801",
+      "e199d460-c88f-4ab9-8373-1d6ad0bd0acb",
+    ]);
+```
+<br/>
+
+Or even using filter criterion (More details in [Filtering records](dataset-operations.html#filtering-records)):
+
+```typescript
+  // a callback that will receive "field" function
+  dom.dataset("posts")
+    .attach("comments", (field) => field("id").isInArray(commentsIds));
+
+  // an exposed "field" function
+  dom.dataset("posts")
+    .attach("comments", field("id").isInArray(commentsIds));
+```
+<br/>
+
+Full example using a callback:
 
 ```typescript
   const firstPost = posts[0];
@@ -239,8 +280,8 @@ be either a **dataset** or a **fileset**) and filter criteria:
   //     ]
   //   }
   // ]
-
 ```
+<br/>
 
 After attaching those comments, you feel regret, and you want to undo it. That's totally acceptable,
 similar to `.attach()`, call `.detach()`:

--- a/src/api/core/queries/actionQuery.spec.ts
+++ b/src/api/core/queries/actionQuery.spec.ts
@@ -5,8 +5,8 @@ import {
   getRandomQueryActionType,
   getRandomResourceType,
 } from "../../../../spec/testUtils";
-import { toQueryParams } from "../../../internal/utils";
-import { toFilteringCriterion } from "../../dataops/filteringApi";
+import { QueryActionType, toQueryParams } from "../../../internal/utils";
+import { field, toFilteringCriterion } from "../../dataops/filteringApi";
 import { ActionQuery } from "./actionQuery";
 
 describe("ActionQuery class", () => {
@@ -34,7 +34,26 @@ describe("ActionQuery class", () => {
     };
   }
 
-  it("should add props to query params by passing a filter", () => {
+  function getExpectedQueryParams(
+    queryActionType: QueryActionType,
+    actionResourceName: string,
+    filter: any,
+  ) {
+    return toQueryParams({
+      action: queryActionType,
+      action_resource: actionResourceName,
+      action_cond: toFilteringCriterion(filter).condition.compile(),
+    });
+  }
+
+  function fakeList(factory: () => any): any {
+    return Array.from(
+      { length: faker.random.number({ min: 1, max: 5 }) },
+      factory,
+    );
+  }
+
+  it("should add props to query params by passing filter criterion", () => {
     const {
       subject,
       requestExecuterMock,
@@ -43,11 +62,11 @@ describe("ActionQuery class", () => {
       queryActionType,
     } = createSubject();
 
-    const expectedQueryParams = toQueryParams({
-      action: queryActionType,
-      action_resource: actionResourceName,
-      action_cond: toFilteringCriterion(filter).condition.compile(),
-    });
+    const expectedQueryParams = getExpectedQueryParams(
+      queryActionType,
+      actionResourceName,
+      filter,
+    );
 
     subject.execute();
 
@@ -57,4 +76,91 @@ describe("ActionQuery class", () => {
       }),
     );
   });
+
+  it("should add props to query params by passing an array of ids", () => {
+    const fakeIdsList = fakeList(() => faker.random.uuid());
+
+    const {
+      subject,
+      requestExecuterMock,
+      actionResourceName,
+      queryActionType,
+    } = createSubject({
+      filter: fakeIdsList,
+    });
+
+    const expectedQueryParams = getExpectedQueryParams(
+      queryActionType,
+      actionResourceName,
+      field("id").isInArray(fakeIdsList),
+    );
+
+    subject.execute();
+
+    expect(requestExecuterMock.executeRequest).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        queryParams: expectedQueryParams,
+      }),
+    );
+  });
+
+  it("should add props to query params by passing an array of objects with id", () => {
+    const fakeObjectsWithIdList = fakeList(() => ({ id: faker.random.uuid() }));
+
+    const {
+      subject,
+      requestExecuterMock,
+      actionResourceName,
+      queryActionType,
+    } = createSubject({
+      filter: fakeObjectsWithIdList,
+    });
+
+    const ids = fakeObjectsWithIdList.map((o: any) => o.id);
+
+    const expectedQueryParams = getExpectedQueryParams(
+      queryActionType,
+      actionResourceName,
+      field("id").isInArray(ids),
+    );
+
+    subject.execute();
+
+    expect(requestExecuterMock.executeRequest).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        queryParams: expectedQueryParams,
+      }),
+    );
+  });
+
+  describe("When passing invalid types", () => {
+    const randomInvalid = () => faker.helpers.randomize(["", undefined, null]);
+    function testError(filter: any) {
+      const create = createSubject.bind(null, { filter });
+
+      expect(create).toThrow("Invalid resource or id list: " + filter);
+    }
+
+    it("should throw error for list with invalid id", () => {
+      testError([
+        randomInvalid(),
+        faker.random.uuid(),
+      ]);
+    });
+
+    it("should throw error for list with invalid object id", () => {
+      testError([
+        { id: randomInvalid() },
+        { id: faker.random.uuid() },
+      ]);
+    });
+
+    it("should throw error for list with mixed types", () => {
+      testError([
+        { id: faker.random.uuid() },
+        faker.random.uuid(),
+      ]);
+    });
+  });
+
 });

--- a/src/api/core/queries/actionQuery.spec.ts
+++ b/src/api/core/queries/actionQuery.spec.ts
@@ -136,9 +136,8 @@ describe("ActionQuery class", () => {
   describe("When passing invalid types", () => {
     const randomInvalid = () => faker.helpers.randomize(["", undefined, null]);
     function testError(filter: any) {
-      const create = createSubject.bind(null, { filter });
-
-      expect(create).toThrow("Invalid resource or id list: " + filter);
+      expect(() => createSubject({ filter }))
+        .toThrow("Invalid resource or id list: " + filter);
     }
 
     it("should throw error for list with invalid id", () => {

--- a/src/api/core/resource.ts
+++ b/src/api/core/resource.ts
@@ -38,6 +38,11 @@ export type DefaultResourceInterface = {
 export type ResourceInterface<T> = T & DefaultResourceInterface;
 
 /**
+ * An array of either ids or resources
+ */
+export type IdentityCollection<T> = string[] | Array<ResourceInterface<T>>;
+
+/**
  * Extract interface from the related resource either its array or a single type
  * and expand it with the default resource fields
  */

--- a/src/api/dataops/dataset.ts
+++ b/src/api/dataops/dataset.ts
@@ -6,7 +6,7 @@ import { DeleteQuery } from "../core/queries/deleteQuery";
 import { InsertQuery } from "../core/queries/insertQuery";
 import { SelectQuery } from "../core/queries/selectQuery";
 import { UpdateQuery } from "../core/queries/updateQuery";
-import { IResource, ResourceInterface, ResourceType } from "../core/resource";
+import { IdentityCollection, IResource, ResourceInterface, ResourceType } from "../core/resource";
 import { DataSetName } from "./dataops.tokens";
 import { IFilteringCriterion, IFilteringCriterionCallback } from "./filteringApi";
 
@@ -114,8 +114,8 @@ export class Dataset<
    */
   public attach(
     resourceName: string,
-    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
-  ): ActionQuery<T> {
+    filter: IFilteringCriterion<D> | IFilteringCriterionCallback<D> | IdentityCollection<D>,
+  ): ActionQuery<T, D> {
     return new ActionQuery(
       this.requestExecuter,
       this.resourceType,
@@ -135,8 +135,8 @@ export class Dataset<
    */
   public detach(
     resourceName: string,
-    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
-  ): ActionQuery<T> {
+    filter: IFilteringCriterion<D> | IFilteringCriterionCallback<D> | IdentityCollection<D>,
+  ): ActionQuery<T, D> {
     return new ActionQuery(
       this.requestExecuter,
       this.resourceType,

--- a/src/api/fileops/fileset.ts
+++ b/src/api/fileops/fileset.ts
@@ -8,7 +8,7 @@ import { ActionQuery } from "../core/queries/actionQuery";
 import { DeleteQuery } from "../core/queries/deleteQuery";
 import { SelectQuery } from "../core/queries/selectQuery";
 import { UpdateQuery } from "../core/queries/updateQuery";
-import { IResource, ResourceType } from "../core/resource";
+import { IdentityCollection, IResource, ResourceType } from "../core/resource";
 import { IFilteringCriterion, IFilteringCriterionCallback } from "../dataops/filteringApi";
 import {
   FileOperationsConfig,
@@ -111,8 +111,10 @@ export class Fileset<FormDataType extends IFormData<F>, T, D, F> implements IRes
    */
   public attach(
     resourceName: string,
-    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
-  ): ActionQuery<T> {
+    filter: IFilteringCriterion<FilesetInterface<T>>
+      | IFilteringCriterionCallback<FilesetInterface<T>>
+      | IdentityCollection<FilesetInterface<T>>,
+  ): ActionQuery<T, FilesetInterface<T>> {
     return new ActionQuery(
       this.requestExecuter,
       this.resourceType,
@@ -132,8 +134,10 @@ export class Fileset<FormDataType extends IFormData<F>, T, D, F> implements IRes
    */
   public detach(
     resourceName: string,
-    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
-  ): ActionQuery<T> {
+    filter: IFilteringCriterion<FilesetInterface<T>>
+      | IFilteringCriterionCallback<FilesetInterface<T>>
+      | IdentityCollection<FilesetInterface<T>>,
+  ): ActionQuery<T, FilesetInterface<T>> {
     return new ActionQuery(
       this.requestExecuter,
       this.resourceType,

--- a/src/internal/query.spec.ts
+++ b/src/internal/query.spec.ts
@@ -67,18 +67,6 @@ describe("Query class", () => {
   });
 
   describe("On setAction", () => {
-    it("should compile with no condition", () => {
-      const queryActionType = getRandomQueryActionType();
-      const actionResource = faker.random.alphaNumeric();
-
-      query.setAction(queryActionType, actionResource);
-
-      expect(query.compile()).toEqual({
-        action: queryActionType,
-        action_resource: actionResource,
-      });
-    });
-
     it("should compile with condition", () => {
       const queryActionType = getRandomQueryActionType();
       const actionResource = faker.random.alphaNumeric();
@@ -173,12 +161,13 @@ describe("Query class", () => {
       const queryActionType = getRandomQueryActionType();
       const actionResource = faker.random.alphaNumeric();
       const field1 = faker.random.alphaNumeric();
+      const filter = getRandomFilteringCriteria();
 
       query.addSortCondition(sort1.direction, ...sort1.fields);
       query.limit = faker.random.number();
       query.offset = faker.random.number();
       query.fields = [field1, aggField];
-      query.setAction(queryActionType, actionResource);
+      query.setAction(queryActionType, actionResource, filter);
       query.setFilterCriteria(filteringCriterion);
 
       expect(query.compile()).toEqual({
@@ -186,6 +175,7 @@ describe("Query class", () => {
         range: { limit: query.limit, offset: query.offset },
         outputs: [field1, "COUNT(id)"],
         action: queryActionType,
+        action_cond: toFilteringCriterion(filter).condition.compile(),
         action_resource: actionResource,
         cond: toFilteringCriterion(filteringCriterion).condition.compile(),
       });

--- a/src/internal/query.ts
+++ b/src/internal/query.ts
@@ -55,7 +55,7 @@ export class Query<T = any> {
   private actionParams: {
     action: QueryActionType;
     actionResource: string;
-    filter?: IFilteringCriterion<T> | IFilteringCriterionCallback<T>;
+    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>;
   };
 
   /*
@@ -83,7 +83,7 @@ export class Query<T = any> {
   public setAction(
     action: QueryActionType,
     actionResource: string,
-    filter?: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
+    filter: IFilteringCriterion<T> | IFilteringCriterionCallback<T>,
   ): void {
     this.actionParams = { action, actionResource, filter };
   }
@@ -127,19 +127,8 @@ export class Query<T = any> {
       const { action, actionResource, filter } = this.actionParams;
       compiledQueryOptions.action = action;
       compiledQueryOptions.action_resource = actionResource;
-
-      if (filter) {
-        compiledQueryOptions.action_cond = toFilteringCriterion(filter).condition.compile();
-      }
+      compiledQueryOptions.action_cond = toFilteringCriterion(filter).condition.compile();
     }
-
-    /* Compile relations
-     * TODO develop relations */
-    /*if (this.relations.length) {
-      compiledQueryOptions.relations = this.relations.reduce((relations, relation) => (
-        { ...relations, [relation.dataset]: relation.compile() }
-      ), {});
-    }*/
 
     return compiledQueryOptions;
   }


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`attach()` and `detach()` methods can only be filtered by passing filter criterion.

Issue Number: N/A

## What is the new behavior?
You can pass an array either of ids, or objects with ids.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```