### PR TITLE
add correlation id

### DIFF
--- a/src/api/realtime/channel.ts
+++ b/src/api/realtime/channel.ts
@@ -53,6 +53,7 @@ export class Channel<T = any> extends Observable<RealTimeEventMessage<T>> {
         return realTimeCommand(this.websocket, {
           command: RealTimeCommandTypes.Publish,
           arguments: { channel: this.name, data },
+          correlation_id: Math.random().toString(),
         });
       })
     );

--- a/src/api/realtime/realTime.interfaces.ts
+++ b/src/api/realtime/realTime.interfaces.ts
@@ -119,6 +119,10 @@ export interface RealTimeCommand {
    * Arguments of the command
    */
   arguments: SubscriptionArgument | JwtRefreshArgument | PublishArgument;
+  /**
+   * It is possible to provide a correlation id in order to match request and response more thoroughly
+   */
+  correlation_id?: string;
 }
 
 /**


### PR DESCRIPTION
When a customer publishes two identical messages to the channel, SDK can mess up the responses. Adding `correlation_id` solves this problem (this could happen only for the messages in a row, so `Math.random()` is good enough).