### PR TITLE
fix(ums): allow fetching user by email

### DIFF
--- a/e2e/stories/ums/ums.e2e.ts
+++ b/e2e/stories/ums/ums.e2e.ts
@@ -25,7 +25,7 @@ describe("User Management Service", () => {
   describe("initialize without API key", () => {
 
     const wrongCredentialsError = new Error(
-      "There was an error on the back-end as a result of your request: 400 Bad Request",
+      "There was an error on the back-end as a result of your request: 401 Unauthorized",
     );
 
     beforeAll(async () => await initWithUMS());
@@ -105,8 +105,7 @@ describe("User Management Service", () => {
         }));
       });
 
-      // TODO Does not work until alias/email token key will be developed
-      xit("should fetch himself by email", async () => {
+      it("should fetch himself by email", async () => {
         const fetchedUSer = await ums.getUser(credentials.email);
         joiAssert(fetchedUSer, UserSchema);
       });

--- a/src/api/core/componentStorage.ts
+++ b/src/api/core/componentStorage.ts
@@ -18,7 +18,7 @@ export interface IStorageComponent {
   /**
    * Return token pair by their alias
    * if alias not provided, returns the default pair
-   * @param auth {string} Authentication alias
+   * @param auth {string} Authentication alias or user email
    */
   getTokens(auth?: string): Tokens;
 

--- a/src/api/ums/umsModule.ts
+++ b/src/api/ums/umsModule.ts
@@ -60,13 +60,7 @@ export class UMSModule implements IModule {
       this.getUrl(API.AUTH, false),
       { body, method: RequestMethod.POST }
     ).then((tokens) => {
-
-      this.tokenManager.addTokens(
-        user.alias || user.email,
-        tokens,
-        user.default,
-      );
-
+      this.tokenManager.addTokens([user.email, user.alias], tokens, user.default);
       return tokens.access_token;
     });
   }


### PR DESCRIPTION
<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

User Management Service module `getUser()` method does not allow to fetch a user by email.

Issue Number: N/A

## What is the new behavior?

Token Manager is able to keep several aliases for each token pair so that a user can be fetched by their email.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

