### PR TITLE
feat(queries): migrate data queries to the observables

### DIFF
--- a/extra_docs/dataset/README.md
+++ b/extra_docs/dataset/README.md
@@ -1,293 +1,238 @@
 # Datasets Module
-A Dataset ia a data storage where data is stored either using a strict schema or without it (schemaless). You are able to manipulate this data by creating, updating, fetching and deleting records, and also to query over them by using conditions like `isEqualTo` and `isGreaterThen` (full list available in [FieldFilter API reference](../classes/FieldFilter.html)).
-
+A Dataset is a data storage where data is stored either using a strict schema or without it (schemaless). You are able to manipulate this data by creating, updating, fetching and deleting records and also to query over them by using conditions like `isEqualTo` and `isGreaterThen` (full list available in [FieldFilter API reference](../classes/FieldFilter.html)).
 
 ### [Initialize](#init) 
-To use dataset features, just add `dataOperations` module to the client initialization. Notice, that for Node.js
-you have to import `dataOperations` from `jexia-sdk-js/node`, but if you are running your application in a browser, you should import it from `jexia-sdk-js/browser`.
+To use dataset features, just add `dataOperations` module to the client initialization. Notice that when your application runs in NodeJS, you should import `dataOperations` from `jexia-sdk-js/node` and from `jexia-sdk-js/browser` when it runs in a browser.
+  
+```javascript  
+import { jexiaClient, dataOperations } from "jexia-sdk-js/node"; // "jexia-sdk-js/browser" for browser applications  
+const dataModule = dataOperations();  
+  
+jexiaClient().init({  
+  projectID: "<your-project-id>",  
+  key: "<your-project-api-key>",  
+  secret: "<your-project-api-secret>",  
+}, dataModule);  
+```  
 
-```typescript
-import { jexiaClient, dataOperations } from "jexia-sdk-js/node"; // "jexia-sdk-js/browser" for browser applications
-
-const dataModule = dataOperations();
-
-jexiaClient().init({
-  projectID: "<your-project-id>",
-  key: "<your-project-api-key>",
-  secret: "<your-project-api-secret>",
-}, dataModule);
+### [Getting a dataset object](#getting-dataset)
+Dataset object can be received from the `dataModule` just by its name:
+```javascript
+const myDataset = dataModule.dataset("my_dataset");
 ```
+Obtained object has all the methods to manage its data - `insert`, `select`, `update` and `delete`: 
+```javascript  
+const selectQuery = myDataset.select();  
+const insertQuery = myDataset.insert([post1, post2]);  
+const updateQuery = myDataset.update([{ title: "Updated title" }]);  
+const deleteQuery = myDataset.delete();  
+```
+These methods return an Observable and allow you to use all the power of RxJS library ([RxJs documentation](https://rxjs.dev/guide/overview)).
 
-### [Inserting records](#inserting-records)
-
-Records can be inserted to a dataset either by sending an array or a single one. The response will always be an array though.
-
-``` Javascript
-[..]
+Let's write something interesting. For example, we want to select records older than 1 day and put them into archive:
+```javascript
+// datasets
 const posts = dataModule.dataset("posts");
+const archive = dataModule.dataset("archive");
 
-// Multiple records
-const insertQuery = posts.insert([
-  { title: "New Post", content: "content here" },
-  { title: "Another Post", content: "some more content" },
+// Calculate yesterday's date
+const date = new Date();  
+date.setDate(date.getDate() - 1);
+const yesterday = date.toISOString();
+
+posts.select()
+  // get all records that had been created earlier than yesterday
+  .where(field => field("created_at").isLessThan(yesterday))
+  .pipe(
+    // put them into archive!
+    switchMap(records => archive.insert(records)),
+  )
+  .subscribe();
+``` 
+
+Pay attention that request to the dataset will not be sent until `subscribe()` method is called.
+
+Let's have a look at each method.  
+  
+### [Inserting records](#inserting-records)  
+  
+Records can be inserted to a dataset either by sending an array or a single object. The response will always be an array though.  
+  
+``` Javascript  
+const posts = dataModule.dataset("posts");  
+  
+const insertQuery = posts.insert([  
+ { title: "New Post", content: "content here" }, 
+ { title: "Another Post", content: "some more content" }
 ]);
 
-// Single record
-const insertQuery = posts.insert({
-  title: "New Post",
-  content: "content here",
-});
+// At this point nothing has happened yet 
+// we need to call subscribe in order to run a query
+insertQuery.subscribe();
+  
+// Single record  
+const insertQuery = posts.insert({  
+ title: "New Post", 
+ content: "content here"
+}).subscribe();  
+  
+// Either way, the response will be an array  
+insertQuery.subscribe(records => { 
+     // you will always get an array of created records, including their generated IDs (even when inserting a single record) 
+  }, 
+  error => { 
+     // you can see the error info here, if something goes wrong 
+});  
+```  
+  
+### [Updating records](#updating-records)  
+  
+The `update` method is used to modify records, it always has to be used with the `.where` method and a filter criteria.  
+  
+```javascript  
+const posts = dataModule.dataset("posts"); 
 
-// Either way, the response will be an array
-insertQuery
-  .execute()
-  .then(records => {
-    // you will always get an array of created records, including their generated IDs (even when inserting a single record)
-  }).catch(error => {
-    // you can see the error info here, if something goes wrong
-  });
-[..]
-```
+posts
+  .update({ title: "Same title for tom and harry posts" }) 
+  .where(field => field("author_name").isInArray(["Tom", "Harry"]))
+  .subscribe(affectedRecords => {
+   /* [{ title: "Same title for tom and harry posts", author_name: "Tom" },       
+       { title: "Same title for tom and harry posts", author_name: "Tom" },   
+       { title: "Same title for tom and harry posts", author_name: "Harry" },
+       { title: "Same title for tom and harry posts", author_name: "Tom" }]   
+    */
+  }); 
+```  
+  
+### [Deleting records](#deleting-records)  
+ Deleting  also requires at least one condition: 
+  
+``` javascript  
+const posts = dataModule.dataset("posts");
 
-### [Updating records](#updating-records)
-
-The `update` method is used to modify records, it always has to be used with the `.where` method and a filter criteria.
-
-``` Javascript
-[..]
-try {
-  const filter = field("author_name").isInArray(["Tom", "Harry"]);
-  const affectedRecords = await dataModule
-    .dataset("posts")
-    .update({ title: "Same title for tom and harry posts" })
-    .where(filter)
-    .execute();
-
-  console.log(affectedRecords);
-  // output: 
-  // [
-  //   { title: "Same title for tom and harry posts", author_name: "Tom" }, 
-  //   { title: "Same title for tom and harry posts", author_name: "Tom" }, 
-  //   { title: "Same title for tom and harry posts", author_name: "Harry" }, 
-  //   { title: "Same title for tom and harry posts", author_name: "Tom" }, 
-  //   ...
-  // ]
-} catch (error) {
-  // you can see the error info here, if something goes wrong
-}
-```
-
-### [Deleting records](#deleting-records)
-
-``` Javascript
-[..]
-try {
-  const posts = await dataModule.dataset("posts")
-    .delete()
-    .where(field("title").isLike("test"))
-    .execute();
+posts
+  .delete()
+  .where(field => field("title").isLike("%test%"))
+  .subscribe(deletedFields => {  
+    // you will be able to access the deleted posts here  
+    // they are not stored in the DB anymore, but maybe you 
+    // want to display a visual confirmation of what was deleted
+  });  
+```  
+  
+### [Query records](#dataset-query-objects)  
+  
+Query object, returned by `select()` method, has an ability to filter, order, limit and offset records. These methods have to be called in chain before `subscribe()`.
+  
+### [Our first query: selecting all records in a dataset](#select-all-dataset-records)  
     
-  // you will be able to access the deleted posts here
-  // they won't be stored in the DB anymore, but maybe you
-  // want to display a visual confirmation of what was deleted
-} catch (error) {
-  // you can see the error info here, if something goes wrong
-}
-[..]
-```
+```javascript  
+const posts = dataModule.dataset("posts");  
 
-### [Query objects](#dataset-query-objects)
-Using an initialized dataset module, you can get `Dataset` objects like:
+posts.select()
+  .subscribe(
+    records => { 
+      // here are all your posts 
+    },
+    error => { 
+      // some error happened 
+    }
+  );     
+```  
+  
+### [Sorting records](#sorting-records)  
+  
+In order to sort records, you need to call `.sortAsc` or `.sortDesc` on a `Query` object and pass the name of the field you want to sort by.  
+  
+```javascript  
+const posts = dataModule.dataset("posts");
 
-``` Javascript
-[..]
-const postsDataset = dataModule.dataset("posts");
-[..]
-```
-
-Using a `Dataset` object, you can get a `Query` object by calling the basic operation methods like:
-
-``` Javascript
-[..]
-const selectQuery = postsDataset.select();
-const insertQuery = postsDataset.insert([post1, post2]);
-const updateQuery = postsDataset.update([{ title: "Updated title" }]);
-const deleteQuery = postsDataset.delete();
-[..]
-```
-
-At this moment the `Query` is not executed yet, you need to call `.execute()` in order to start the request. `.execute()` returns a `Promise` resolving to a set of records, regardless of the type of `Query` executed.
-
-Each different `Query` type has different support for query options (filtering, sorting, etc.). By the way, you cannot add queries to `InsertQuery` as it does not implement `.where` (and it wouldn't make any sense to do so, right?).
-
-### [Our first query: selecting all records in a dataset](#select-all-dataset-records)
-
-Notice that some variables used by the following examples are for demonstration purposes, mostly to point out the different objects and functionality involved when working with records.
-
-``` Javascript
-[..]
-jexiaClient().init(credentials, dataModule);
-
-const postsDataset = dataModule.dataset("posts");
-const unexecutedQuery = postsDataset.select();
-const executedQueryPromise = unexecutedQuery.execute();
-
-try {
-  const posts = await executedQueryPromise;
-  // you can start iterating with posts here
-} catch (error) {
-  // there was a problem retrieving the records 
-}
-[..]
-```
-
-If you watch closely, the API is chainable, so you can rewrite the query in a much less verbose way:
-
-``` Javascript
-[..]
-jexiaClient().init(credentials, dataModule);
-
-try {
-  const posts = await dataModule.dataset("posts")
-    .select()
-    .execute();
-  // you can start iterating with posts here
-} catch (error) {
-  // there was a problem retrieving the records 
-}
-[..]
-```
-
-But at the very least, defining dataset variables could come in handy when executing multiple different queries on the same dataset.
-
-### [Sorting records](#sorting-records)
-
-In order to sort records, you need to call `.sortAsc` or `.sortDesc` on a `Query` object and pass the name of the field you want to sort by.
-
-``` Javascript
-[..]
-const sortedPosts = await dataModule.dataset("posts")
+posts
   .select()
   .sortAsc("created_at")
-  .execute();
+  .subscribe(records => { 
+    // you've got sorted records here 
+  });
+```  
+  
+### [Limit and offset](#limit-offset)  
+  
+You can use `.limit` and `.offset` on a `Query` to paginate your records. They can be used separately or together. Only setting the limit (to a value X) will make the query operate on the first X records. Only setting the `offset` will make the query operate on the last Y records, starting from the `offset` value.  
+  
+```javascript  
+const posts = dataModule.dataset("posts");
 
-console.log(sortedPosts)
-// output: 
-// [
-//   { created_at: "2019-01-10T00:00:32.000Z", author_name: "Tom" }, 
-//   { created_at: "2019-02-15T00:10:00.000Z", author_name: "Helen" }, 
-//   { created_at: "2008-02-16T00:12:00.000Z", author_name: "Harry" },
-//   { created_at: "2008-02-16T10:45:00.000Z", author_name: "Mary" },
-//   ...
-// ]
-[..]
-```
-
-### [Limit and offset](#limit-offset)
-
-You can use `.limit` and `.offset` on a `Query` to paginate your records. They can be used separately or together. Only setting the limit (to a value X) will make the query operate on the first X records. Only setting the `offset` will make the query operate on the last Y records, starting from the `offset` value.
-
-``` Javascript
-[..]
-const paginatedPosts = await dataModule.dataset("posts")
-  .select()
+posts.select()
   .limit(2)
   .offset(5)
-  .execute();
+  .subscribe(records => // paginatedPosts will be an array of 2 records, starting from position 5);
+```  
+  
+### [Only retrieving certain fields](#retrieve-certain-fields)  
+  
+You can use `.fields` method to restrict fields you want to retrieve.  
+  
+```javascript
+const posts = dataModule.dataset("posts");
 
-// paginatedPosts will be an array of 2 records, starting from position 5
-[..]
-```
-
-### [Only retrieving certain fields](#retrieve-certain-fields)
-
-You can use `.fields` method to restrict fields you want to retrieve.
-
-``` Javascript
-[..]
-const posts = await dataModule.dataset("posts")
-  .select()
-  .fields("id", "title") // you can also pass an array of field names too
-  .execute();
-
-console.log(posts);
-// output:
-// [ 
-//   { id: "78574c6a-b5a0-45da-a589-9671a88f7f53", title: "Some post title" },
-//   { id: "1b118939-85fc-47f0-9b4f-a6de00922e15", title: "Some other post title" },
-// ]
-[..]
-```
-
-### [Filtering records](#filtering-records)
-
-You can use the filtering to select what records a certain query will operate on.
-
-In order to define a filter, you can use the exposed method `field`.
-
-``` Typescript
-import { field } from "jexia-sdk-js/node";
-
-const isAuthorTom = field("author_name").isEqualTo("Tom");
-const isAuthorDick = field("author_name").isEqualTo("Dick");
-const isAuthorTomOrDick = isAuthorTom.or(isAuthorDick);
-
-// In order to use these conditions, they need to be added to a query through `.where` method
-
-dataModule.dataset("posts")
-  .select()
-  .where(isAuthorTomOrDick);
-
-[..]
-```
-
-If you prefer, `.where` method also accepts a lazy callback, that receives the `field` method received as an argument:
-
-``` Javascript
-[..]
-dataModule.dataset("posts")
-  .select()
-  .where(field => field("author_name").isEqualTo("Harry"));
-[..]
-```
-
-Multiple `.where` calls can be chained, but only the last call will be taken into account. If a complex condition needs to be set for filtering, it has to be created in one go (in-line or not) and passed as an argument to the `.where` method.
-
-Filtering conditions can be nested at any level.
-
-``` Javascript
-[..]
-// Filtering in a flat way
-const isPostedByTomAndIsAboutSports = field("author_name")
-  .isEqualTo("Tom")
-  .and(field("title").isLike("sports"));
-
-// Filtering with one nested level
-const isPostedByDickAndIsAboutMusic = field("author_name")
-  .isEqualTo("Dick")
-  .and(field("title").isLike("music"));
-
-const isTomOrIsDickHarry = field("author_name")
-  .isEqualTo("Tom")
-  .or(
-    isPostedByDickAndIsAboutMusic // nested level
-  );
-
-// Filtering with multiple nested levels
-const isAuthorDutch = field("author_country").isEqualTo("NL");
-const isKidOrSenior = field("author_age")
-  .isGreaterThan(64)
-  .or(field("author_age").isLessThan(16));
-
-const isTomAndIsDuthOrKidOrSenior = field("first_name")
-  .isEqualTo("Tom")
-  .and(
-    isAuthorDutch.or(isKidOrSenior)
-  );
-[..]
-```
-
-### [Filtering operator list and examples](#filtering-operator-list)
-
+posts.select()
+  .fields("title", "author") // you can also pass an array of field names 
+  .subscribe(records => // you will get array of {id, title, author} records (id is always returned));
+```  
+  
+### [Filtering records](#filtering-records)  
+  
+You can use the filtering to select what records a certain query will operate on.  
+  
+In order to define a filter, you can use the exposed method `field`.  
+  
+```javascript
+import { field } from "jexia-sdk-js/node";  
+  
+const isAuthorTom = field("author_name").isEqualTo("Tom");  
+const isAuthorDick = field("author_name").isEqualTo("Dick");  
+const isAuthorTomOrDick = isAuthorTom.or(isAuthorDick);  
+  
+// In order to use these conditions, they need to be added to a query through `.where` method  
+  
+dataModule.dataset("posts")  
+ .select()
+ .where(isAuthorTomOrDick)
+ .subscribe(records => // posts of Tom and Dick);  
+```  
+  
+If you prefer, `.where` method also accepts a lazy callback, that receives the `field` method received as an argument:  
+  
+```javascript  
+dataModule.dataset("posts")  
+ .select() 
+ .where(field => field("author_name").isEqualTo("Harry"));  
+```  
+  
+Multiple `.where` calls can be chained, but only the last call will be taken into account. If a complex condition needs to be set for filtering, it has to be created in one go (in-line or not) and passed as an argument to the `.where` method.  
+  
+Filtering conditions can be nested at any level.  
+  
+```javascript  
+// Filtering in a flat way  
+const isPostedByTomAndIsAboutSports = field("author_name")  
+ .isEqualTo("Tom").and(field("title").isLike("sports"));  
+ 
+// Filtering with one nested level  
+const isPostedByDickAndIsAboutMusic = field("author_name")  
+ .isEqualTo("Dick").and(field("title").isLike("music"));  
+ 
+const isTomOrIsDickHarry = field("author_name")  
+ .isEqualTo("Tom").or( isPostedByDickAndIsAboutMusic // nested level );  
+ 
+// Filtering with multiple nested levels  
+const isAuthorDutch = field("author_country").isEqualTo("NL");  
+const isKidOrSenior = field("author_age")  
+ .isGreaterThan(64).or(field("author_age").isLessThan(16));  
+const isTomAndIsDuthOrKidOrSenior = field("first_name")  
+ .isEqualTo("Tom").and( isAuthorDutch.or(isKidOrSenior) );
+```  
+  
+### [Filtering operator list and examples](#filtering-operator-list)  
+  
 You can find a complete list of the operators supported for filtering in the [FieldFilter API reference](../classes/FieldFilter.html).
-

--- a/extra_docs/jfs/README.md
+++ b/extra_docs/jfs/README.md
@@ -187,10 +187,10 @@ These fields, as well as any custom fields, can be used for select queries (but 
 
 #### Select query
 ```typescript  
-const files = await jfs.fileset("fileset_name")  
+jfs.fileset("fileset_name")  
  .select("name", "url")  
  .where(field => field("size").isGreaterThan(1024000))  
- .execute();  
+ .subscribe();  
   
 // array of files that fit to the condition will be returned  
 // files === [{ name: "file1.jpj", url: "https://..." }, {...}, ...]  
@@ -200,15 +200,15 @@ const files = await jfs.fileset("fileset_name")
 Update fileset in the same way as dataset. Updating a fileset record with new file is not supported.
   
 ```typescript  
-await jfs.fileset("fileset_name")  
+jfs.fileset("fileset_name")  
  .update({ "isDefaultImage": false })  
  .where(field => field("name").isEqualTo("companyLogo.png"))
- .execute();  
+ .subscribe();  
 ```  
 #### Delete query
 ```typescript  
-await jfs.fileset("fileset_name")  
+jfs.fileset("fileset_name")  
  .delete()  
  .where(field => field("size").isGreaterThan(1024000))  
- .execute();  
+ .subscribe();  
 ```

--- a/src/api/core/queries/actionQuery.spec.ts
+++ b/src/api/core/queries/actionQuery.spec.ts
@@ -68,7 +68,7 @@ describe("ActionQuery class", () => {
       filter,
     );
 
-    subject.execute();
+    subject.subscribe();
 
     expect(requestExecuterMock.executeRequest).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -95,7 +95,7 @@ describe("ActionQuery class", () => {
       field("id").isInArray(fakeIdsList),
     );
 
-    subject.execute();
+    subject.subscribe();
 
     expect(requestExecuterMock.executeRequest).toHaveBeenLastCalledWith(
       expect.objectContaining({
@@ -124,7 +124,7 @@ describe("ActionQuery class", () => {
       field("id").isInArray(ids),
     );
 
-    subject.execute();
+    subject.subscribe();
 
     expect(requestExecuterMock.executeRequest).toHaveBeenLastCalledWith(
       expect.objectContaining({

--- a/src/api/core/queries/insertQuery.spec.ts
+++ b/src/api/core/queries/insertQuery.spec.ts
@@ -27,12 +27,13 @@ describe("InsertQuery class", () => {
 
   it("should execute the query with the correct parameters", () => {
     spyOn(qe, "executeRequest");
-    subject.execute();
+    subject.subscribe();
     expect(qe.executeRequest).toHaveBeenLastCalledWith({
       method: RequestMethod.POST,
       body: [fakeRecord],
       resourceType,
-      resourceName
+      resourceName,
+      queryParams: []
     });
   });
 });

--- a/src/api/core/queries/insertQuery.ts
+++ b/src/api/core/queries/insertQuery.ts
@@ -20,7 +20,7 @@ import { BaseQuery } from "./baseQuery";
  * @template T Generic type of your dataset, default to any
  * @template D Extended dataset type with default fields (i.e id, created_at, updated_at)
  */
-export class InsertQuery<T, D extends T> extends BaseQuery<T> {
+export class InsertQuery<T, D extends T> extends BaseQuery<D> {
   /**
    * @inheritdoc
    */
@@ -32,18 +32,5 @@ export class InsertQuery<T, D extends T> extends BaseQuery<T> {
   public constructor(queryExecuter: RequestExecuter, records: T[], resourceType: ResourceType, resourceName: string) {
     super(queryExecuter, RequestMethod.POST, resourceType, resourceName);
     this.body = records;
-  }
-
-  /**
-   * Overload parent execute request to call rest API
-   * @returns {Promise<D[]>}
-   */
-  public execute(): Promise<D[]> {
-    return this.queryExecuter.executeRequest({
-      resourceType: this.resourceType,
-      resourceName: this.resourceName,
-      method: this.method,
-      body: this.body,
-    });
   }
 }

--- a/src/api/core/queries/selectQuery.spec.ts
+++ b/src/api/core/queries/selectQuery.spec.ts
@@ -157,7 +157,7 @@ describe("SelectQuery class", () => {
     const { subject } = createSubject();
     subject.fields("id");
     spyOn(subject["queryExecuter"], "executeRequest");
-    subject.execute();
+    subject.subscribe();
     expect(subject["queryExecuter"].executeRequest).toHaveBeenLastCalledWith((subject as any).compiledRequest);
   });
 

--- a/src/api/core/queries/updateQuery.spec.ts
+++ b/src/api/core/queries/updateQuery.spec.ts
@@ -42,7 +42,7 @@ describe("QueryRequest class", () => {
       requestExecuterMock: createRequestExecuterMock() as SpyObj<RequestExecuter>,
     });
     spyOn(requestExecuterMock, "executeRequest");
-    subject.execute();
+    subject.subscribe();
     expect(requestExecuterMock.executeRequest).toHaveBeenLastCalledWith(subject["compiledRequest"]);
   });
 });


### PR DESCRIPTION
Old data request syntax:
```javascript
dataet.select()
  .execute()
  .then(result => {
     // enjoy your result
   })
  .catch(error => // do something with error)
```

new syntax:
```javascript
dataset.select()
  .subscribe(result => {
    // enjoy your result
  }, error => // do something with error);
```