### PR TITLE
feat(sets): allow to initiate a list of resources at a time

### DIFF
--- a/extra_docs/dataset/README.md
+++ b/extra_docs/dataset/README.md
@@ -20,6 +20,11 @@ Dataset object can be received from the `dataModule` just by its name:
 ```javascript
 const myDataset = dataModule.dataset("my_dataset");
 ```
+It is also possible to get a list of datasets at a time:
+```javascript
+const [posts, authors] = dataModule.datasets(["posts", "authors"]);
+```
+
 Obtained object has all the methods to manage its data - `insert`, `select`, `update` and `delete`: 
 ```javascript  
 const selectQuery = myDataset.select();  

--- a/src/api/dataops/dataOperationsModule.spec.ts
+++ b/src/api/dataops/dataOperationsModule.spec.ts
@@ -49,6 +49,21 @@ describe("Real Time Module", () => {
 
   });
 
+  describe("when gets a list of datasets", () => {
+    it("should return correct dataset list", async () => {
+      const { subject, moduleInit } = createSubject();
+      await moduleInit();
+
+      const names = ["d1", "d2", "d3"];
+      const datasets = subject.datasets(names);
+
+      datasets.forEach((dataset, index) => {
+        expect(dataset).toBeInstanceOf(Dataset);
+        expect(dataset.name).toEqual(names[index]);
+      });
+    });
+  });
+
   describe("when gets a module config", () => {
 
     it("should return an empty config", () => {

--- a/src/api/dataops/dataOperationsModule.ts
+++ b/src/api/dataops/dataOperationsModule.ts
@@ -72,6 +72,23 @@ export class DataOperationsModule implements IModule {
     ]).get(Dataset);
   }
 
+  /* tslint:disable:max-line-length */
+  public datasets<A extends {}, B extends {}>(datasets: [string, string], auth?: string): [Dataset<A>, Dataset<B>];
+  public datasets<A extends {}, B extends {}, C extends {}>(datasets: [string, string, string], auth?: string): [Dataset<A>, Dataset<B>, Dataset<C>];
+  public datasets<A extends {}, B extends {}, C extends {}, D extends {}>(datasets: [string, string, string, string], auth?: string): [Dataset<A>, Dataset<B>, Dataset<C>, Dataset<D>];
+  public datasets<A extends {}, B extends {}, C extends {}, D extends {}, E extends {}>(datasets: [string, string, string, string, string], auth?: string): [Dataset<A>, Dataset<B>, Dataset<C>, Dataset<D>, Dataset<E>];
+  public datasets<A extends {}, B extends {}, C extends {}, D extends {}, E extends {}, F extends {}>(datasets: [string, string, string, string, string, string], auth?: string): [Dataset<A>, Dataset<B>, Dataset<C>, Dataset<D>, Dataset<E>, Dataset<F>];
+  public datasets(datasets: string[], auth?: string): Dataset[];
+
+  /**
+   * Generates a list of datasets by given array of dataset names
+   * @param datasets array of dataset names
+   * @param auth optional user authorization alias
+   */
+  public datasets(datasets: string[], auth?: string) {
+    return datasets.map((dataset) => this.dataset(dataset, auth));
+  }
+
   /**
    * @internal
    */

--- a/src/api/fileops/fileOperationsModule.spec.ts
+++ b/src/api/fileops/fileOperationsModule.spec.ts
@@ -66,6 +66,21 @@ describe("File Operations Module", () => {
     });
   });
 
+  describe("when gets a list of filesets", () => {
+    it("should return correct fileset list", async () => {
+      const { subject, moduleInit } = createSubject();
+      await moduleInit();
+
+      const names = ["f1", "f2", "f3"];
+      const filesets = subject.filesets(names);
+
+      filesets.forEach((fileset, index) => {
+        expect(fileset).toBeInstanceOf(Fileset);
+        expect(fileset.name).toEqual(names[index]);
+      });
+    });
+  });
+
   describe("when terminating", () => {
     it("should resolve automatically", async () => {
       const { subject } = createSubject();

--- a/src/api/fileops/fileOperationsModule.ts
+++ b/src/api/fileops/fileOperationsModule.ts
@@ -71,6 +71,28 @@ export class FileOperationsModule<FormDataType extends IFormData<F>, F> implemen
     return injector.get(Fileset);
   }
 
+  /* tslint:disable:max-line-length */
+  public filesets<A extends {}, B extends {}>(filesets: [string, string], auth?: string):
+    [Fileset<FormDataType, A, FilesetInterface<A>, F>, Fileset<FormDataType, B, FilesetInterface<B>, F>];
+  public filesets<A extends {}, B extends {}, C extends {}>(filesets: [string, string, string], auth?: string):
+    [Fileset<FormDataType, A, FilesetInterface<A>, F>, Fileset<FormDataType, B, FilesetInterface<B>, F>, Fileset<FormDataType, C, FilesetInterface<C>, F>];
+  public filesets<A extends {}, B extends {}, C extends {}, D extends {}>(filesets: [string, string, string, string], auth?: string):
+    [Fileset<FormDataType, A, FilesetInterface<A>, F>, Fileset<FormDataType, B, FilesetInterface<B>, F>, Fileset<FormDataType, C, FilesetInterface<C>, F>, Fileset<FormDataType, D, FilesetInterface<D>, F>];
+  public filesets<A extends {}, B extends {}, C extends {}, D extends {}, E extends {}>(filesets: [string, string, string, string, string], auth?: string):
+    [Fileset<FormDataType, A, FilesetInterface<A>, F>, Fileset<FormDataType, B, FilesetInterface<B>, F>, Fileset<FormDataType, C, FilesetInterface<C>, F>, Fileset<FormDataType, D, FilesetInterface<D>, F>, Fileset<FormDataType, E, FilesetInterface<E>, F>];
+  public filesets<A extends {}, B extends {}, C extends {}, D extends {}, E extends {}, G extends {}>(filesets: [string, string, string, string, string, string], auth?: string):
+    [Fileset<FormDataType, A, FilesetInterface<A>, F>, Fileset<FormDataType, B, FilesetInterface<B>, F>, Fileset<FormDataType, C, FilesetInterface<C>, F>, Fileset<FormDataType, D, FilesetInterface<D>, F>, Fileset<FormDataType, E, FilesetInterface<E>, F>, Fileset<FormDataType, G, FilesetInterface<G>, F>];
+  public filesets(filesets: string[], auth?: string): Array<Fileset<FormDataType, any, FilesetInterface<any>, F>>;
+
+  /**
+   * Generates a list of filesets by given array of Fileset names
+   * @param filesets array of Fileset names
+   * @param auth optional user authorization alias
+   */
+  public filesets(filesets: string[], auth?: string) {
+    return filesets.map((fileset) => this.fileset(fileset, auth));
+  }
+
   public terminate(): Promise<this> {
     return Promise.resolve(this);
   }


### PR DESCRIPTION
Currently, it is only possible to get one resource (either dataset or fileset at a time):
```typescript
const posts = dataOperation.dataset("posts");
const authors = dataOperation.dataset("authors");
```

This PR adds `datasets()` and `filesets()` methods which allow getting a list of resources:
```typescript
const [posts, authors] = dataOperation.datasets(["posts", "authors"]);
```

Setting a type of each resource is also supported:
```typescript
const [posts, authors] = dataOperation.datasets<Post, Author>(["posts", "authors"]);
```