### PR TITLE
fix(browser): when calling global "process" an error is being thrown

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -2,8 +2,10 @@ import { API as DEFAULT_API, DELAY } from "./config";
 
 let API = DEFAULT_API;
 
-/* for development purpose */
-if (process && process.env && process.env.JEXIA_DEV_DOMAIN) {
+const isNodeJS = typeof process === "object";
+
+// for development purposes we override domain in order to run e2e tests in a given environment
+if (isNodeJS && process.env && process.env.JEXIA_DEV_DOMAIN) {
   API.DOMAIN = process.env.JEXIA_DEV_DOMAIN;
 }
 


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

While loading sdk in browser, a `ReferenceError` is thrown because it cannot find `process` variable (see screenshot)

<img width="446" alt="Screenshot 2020-01-22 at 11 14 08" src="https://user-images.githubusercontent.com/4020905/72888957-f0fa6680-3d0e-11ea-924b-413ab2a5b9d2.png">


Issue Number: N/A

## What is the new behavior?

Check whether `window` object is defined, so we know whether we're in a browser.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
