### PR TITLE
feat: add project zone config to client initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ const dataModule = jexiaSDK.dataOperations();
 
 const credentials = {
   projectID: "<your-project-id>",
+  zone: "<your-project-zone>",
   key: "<your-project-api-key>",
   secret: "<your-project-api-secret>",
 };

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -3,7 +3,7 @@
 ## Running tests
 ```
 > npm run cross-env NODE_TLS_REJECT_UNAUTHORIZED='0' JEXIA_DEV_DOMAIN='stag | com' E2E_PROJECT_ID='<project_id>'
-  E2E_EMAIL='<user_email>' E2E_PASSWORD='<user_password>' RECAPTCHA_TOKEN='E2E.Tests.Recaptcha.Token'
+  E2E_PROJECT_ZONE='<project_zone>' E2E_EMAIL='<user_email>' E2E_PASSWORD='<user_password>' RECAPTCHA_TOKEN='E2E.Tests.Recaptcha.Token'
   npm run test:e2e
 ```
 

--- a/e2e/browser/index.html
+++ b/e2e/browser/index.html
@@ -13,6 +13,7 @@
       let jfs = jexia.fileOperations();
       let credentials = {
         projectID: 'change-to-valid-project-id',
+        zone: 'change-to-valid-zone',
         key: 'change-to-valid-key',
         secret: 'change-to-valid-secret',
       };

--- a/e2e/teardowns.ts
+++ b/e2e/teardowns.ts
@@ -1,4 +1,5 @@
 import { IModule } from "../src/api/core/module";
+import { DEFAULT_PROJECT_ZONE } from "../src/api/core/tokenManager";
 import {
   Client,
   dataOperations,
@@ -62,6 +63,7 @@ export const init = async (
 
   client = await jexiaClient().init({
     projectID: process.env.E2E_PROJECT_ID as string,
+    zone: (process.env.E2E_PROJECT_ZONE || DEFAULT_PROJECT_ZONE) as string,
     key: apiKey.key,
     secret: apiKey.secret,
   }, ...modules); // Change to LogLevel.DEBUG to have more logs
@@ -99,6 +101,7 @@ export const initWithChannel = async (channelName: string, history = false) => {
 
   client = await jexiaClient().init({
     projectID: process.env.E2E_PROJECT_ID as string,
+    zone: (process.env.E2E_PROJECT_ZONE || DEFAULT_PROJECT_ZONE) as string,
     key: apiKey.key,
     secret: apiKey.secret,
   }, rtm, new LoggerModule(LogLevel.ERROR));
@@ -107,6 +110,7 @@ export const initWithChannel = async (channelName: string, history = false) => {
 export const initWithUMS = async () => {
   client = await jexiaClient().init({
     projectID: process.env.E2E_PROJECT_ID as string,
+    zone: (process.env.E2E_PROJECT_ZONE || DEFAULT_PROJECT_ZONE) as string,
   }, ums, dom, new LoggerModule(LogLevel.ERROR)); // Change to LogLevel.DEBUG to have more logs
 };
 
@@ -126,6 +130,7 @@ export const initWithJFS = async (filesetName: string = "testFileset",
 
   client = await jexiaClient().init({
     projectID: process.env.E2E_PROJECT_ID as string,
+    zone: (process.env.E2E_PROJECT_ZONE || DEFAULT_PROJECT_ZONE) as string,
     key: apiKey.key,
     secret: apiKey.secret,
   }, jfs, realTime(), new LoggerModule(LogLevel.ERROR));
@@ -157,6 +162,7 @@ export const initForRelations = async () => {
 
   client = await jexiaClient().init({
     projectID: process.env.E2E_PROJECT_ID as string,
+    zone: (process.env.E2E_PROJECT_ZONE || DEFAULT_PROJECT_ZONE) as string,
     key: apiKey.key,
     secret: apiKey.secret,
   }, dom, new LoggerModule(LogLevel.DEBUG));

--- a/spec/testUtils.ts
+++ b/spec/testUtils.ts
@@ -150,6 +150,7 @@ export function deepClone<T>(obj: T): T {
 export const validClientOpts = {
   key: "validKey",
   projectID: "validProjectID",
+  zone: "validZone",
   refreshInterval: 500,
   secret: "validSecret",
 };

--- a/src/api/core/tokenManager.ts
+++ b/src/api/core/tokenManager.ts
@@ -9,6 +9,11 @@ import { TokenStorage } from "./componentStorage";
 const APIKEY_DEFAULT_ALIAS = "apikey";
 
 /**
+ * The default project zone
+ */
+export const DEFAULT_PROJECT_ZONE = "NL00";
+
+/**
  * API interface of the authorization token
  */
 export type Tokens = {
@@ -30,6 +35,10 @@ export interface IAuthOptions {
    * Project ID
    */
   readonly projectID: string;
+  /**
+   * Project Zone
+   */
+  readonly zone?: string;
   /**
    * Authorization alias. Used for multiple authorization methods at the same time
    * by default used 'apikey'

--- a/src/internal/executer.ts
+++ b/src/internal/executer.ts
@@ -3,7 +3,7 @@ import { combineLatest, from, Observable } from "rxjs";
 import { map, switchMap } from "rxjs/operators";
 import { ClientInit } from "../api/core/client";
 import { ResourceType } from "../api/core/resource";
-import { AuthOptions, IAuthOptions, TokenManager } from "../api/core/tokenManager";
+import { AuthOptions, DEFAULT_PROJECT_ZONE, IAuthOptions, TokenManager } from "../api/core/tokenManager";
 import { API } from "../config";
 import { QueryParam } from "../internal/utils";
 import { IRequestExecuterData } from "./executer.interfaces";
@@ -34,6 +34,14 @@ export class RequestExecuter {
     ]).pipe(
       switchMap(([, options]) => this.requestAdapter.execute(URI, options) as Observable<T>)
     );
+  }
+
+  /**
+   * The project's API URL
+   */
+  public get apiUrl(): string {
+    const { projectID, zone } = this.config;
+    return `${API.PROTOCOL}://${projectID}.${zone || DEFAULT_PROJECT_ZONE}.${API.HOST}.${API.DOMAIN}:${API.PORT}`;
   }
 
   private getRequestOptions(request: IRequestExecuterData): Observable<IRequestOptions> {
@@ -79,10 +87,9 @@ export class RequestExecuter {
   }
 
   private getUrl({ resourceType, resourceName }: IRequestExecuterData): string {
-    const endpoint = resourceEndpoints[resourceType];
     return [
-      `${API.PROTOCOL}://${this.config.projectID}.${API.HOST}.${API.DOMAIN}:${API.PORT}`,
-      endpoint,
+      this.apiUrl,
+      resourceEndpoints[resourceType],
       resourceName,
     ].join("/");
   }


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently projects API URLs are hosted under `<project-id>.app.jexia.com`

Issue Number: N/A

## What is the new behavior?
Projects are now hosted under `<project-zone>.<project-id>.app.jexia.com`, so zone config parameter is required. The current projects will keep working without changes for a while.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

