### PR TITLE
feat(query): add alias support to query aggregation functions

### DIFF
--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -27,8 +27,8 @@ export const api = {
     delete: `${MANAGEMENT}/${process.env.E2E_PROJECT_ID}/utgard/{key}`
   },
   policy: {
-    create: `${MANAGEMENT}/${process.env.E2E_PROJECT_ID}/rakshak/`,
-    delete: `${MANAGEMENT}/${process.env.E2E_PROJECT_ID}/rakshak/{policy_id}`
+    create: `${MANAGEMENT}/${process.env.E2E_PROJECT_ID}/rakshak/policies/`,
+    delete: `${MANAGEMENT}/${process.env.E2E_PROJECT_ID}/rakshak/policies/{policy_id}`
   },
   ums: {
     schema: `${MANAGEMENT}/${process.env.E2E_PROJECT_ID}/midgard/schema`,

--- a/e2e/management.ts
+++ b/e2e/management.ts
@@ -149,8 +149,7 @@ export class Management {
       headers: this.headers,
       body: JSON.stringify({
         description: "test_policy",
-        actions: ["read", "create", "update", "delete"],
-        effect: "allow",
+        actions: { read: [], create: [], update: [], delete: [] },
         subjects: keys,
         resources: resources.map((resource) => resource.id),
       })

--- a/e2e/stories/dataset/aggregations.e2e.ts
+++ b/e2e/stories/dataset/aggregations.e2e.ts
@@ -90,4 +90,17 @@ describe("Dataset aggregation functions", () => {
         error: done.fail,
       });
   });
+
+  it("should use alias if it is provided", (done) => {
+    dom.dataset(DEFAULT_DATASET.NAME)
+      .select()
+      .fields({ fn: "max", col: "age", alias: "max_age" })
+      .subscribe({
+        next: (result) => {
+          expect(result).toEqual([{ max_age: 42 }]);
+          done();
+        },
+        error: done.fail,
+      });
+  });
 });

--- a/extra_docs/dataset/README.md
+++ b/extra_docs/dataset/README.md
@@ -1,19 +1,19 @@
 # Datasets Module
 A Dataset is a data storage where data is stored either using a strict schema or without it (schemaless). You are able to manipulate this data by creating, updating, fetching and deleting records and also to query over them by using conditions like `isEqualTo` and `isGreaterThen` (full list available in [FieldFilter API reference](../classes/FieldFilter.html)).
 
-### [Initialize](#init) 
+### [Initialize](#init)
 To use dataset features, just add `dataOperations` module to the client initialization. Notice that when your application runs in NodeJS, you should import `dataOperations` from `jexia-sdk-js/node` and from `jexia-sdk-js/browser` when it runs in a browser.
-  
-```javascript  
-import { jexiaClient, dataOperations } from "jexia-sdk-js/node"; // "jexia-sdk-js/browser" for browser applications  
-const dataModule = dataOperations();  
-  
-jexiaClient().init({  
-  projectID: "<your-project-id>",  
-  key: "<your-project-api-key>",  
-  secret: "<your-project-api-secret>",  
-}, dataModule);  
-```  
+
+```javascript
+import { jexiaClient, dataOperations } from "jexia-sdk-js/node"; // "jexia-sdk-js/browser" for browser applications
+const dataModule = dataOperations();
+
+jexiaClient().init({
+  projectID: "<your-project-id>",
+  key: "<your-project-api-key>",
+  secret: "<your-project-api-secret>",
+}, dataModule);
+```
 
 ### [Getting a dataset object](#getting-dataset)
 Dataset object can be received from the `dataModule` just by its name:
@@ -25,12 +25,12 @@ It is also possible to get a list of datasets at a time:
 const [posts, authors] = dataModule.datasets(["posts", "authors"]);
 ```
 
-Obtained object has all the methods to manage its data - `insert`, `select`, `update` and `delete`: 
-```javascript  
-const selectQuery = myDataset.select();  
-const insertQuery = myDataset.insert([post1, post2]);  
-const updateQuery = myDataset.update([{ title: "Updated title" }]);  
-const deleteQuery = myDataset.delete();  
+Obtained object has all the methods to manage its data - `insert`, `select`, `update` and `delete`:
+```javascript
+const selectQuery = myDataset.select();
+const insertQuery = myDataset.insert([post1, post2]);
+const updateQuery = myDataset.update([{ title: "Updated title" }]);
+const deleteQuery = myDataset.delete();
 ```
 These methods return an Observable and allow you to use all the power of RxJS library ([RxJs documentation](https://rxjs.dev/guide/overview)).
 
@@ -41,7 +41,7 @@ const posts = dataModule.dataset("posts");
 const archive = dataModule.dataset("archive");
 
 // Calculate yesterday's date
-const date = new Date();  
+const date = new Date();
 date.setDate(date.getDate() - 1);
 const yesterday = date.toISOString();
 
@@ -53,137 +53,137 @@ posts.select()
     switchMap(records => archive.insert(records)),
   )
   .subscribe();
-``` 
+```
 
 Pay attention that request to the dataset will not be sent until `subscribe()` method is called.
 
-Let's have a look at each method.  
-  
-### [Inserting records](#inserting-records)  
-  
-Records can be inserted to a dataset either by sending an array or a single object. The response will always be an array though.  
-  
-``` Javascript  
-const posts = dataModule.dataset("posts");  
-  
-const insertQuery = posts.insert([  
- { title: "New Post", content: "content here" }, 
+Let's have a look at each method.
+
+### [Inserting records](#inserting-records)
+
+Records can be inserted to a dataset either by sending an array or a single object. The response will always be an array though.
+
+``` Javascript
+const posts = dataModule.dataset("posts");
+
+const insertQuery = posts.insert([
+ { title: "New Post", content: "content here" },
  { title: "Another Post", content: "some more content" }
 ]);
 
-// At this point nothing has happened yet 
+// At this point nothing has happened yet
 // we need to call subscribe in order to run a query
 insertQuery.subscribe();
-  
-// Single record  
-const insertQuery = posts.insert({  
- title: "New Post", 
+
+// Single record
+const insertQuery = posts.insert({
+ title: "New Post",
  content: "content here"
-}).subscribe();  
-  
-// Either way, the response will be an array  
-insertQuery.subscribe(records => { 
-     // you will always get an array of created records, including their generated IDs (even when inserting a single record) 
-  }, 
-  error => { 
-     // you can see the error info here, if something goes wrong 
-});  
-```  
-  
-### [Updating records](#updating-records)  
-  
-The `update` method is used to modify records, it always has to be used with the `.where` method and a filter criteria.  
-  
-```javascript  
-const posts = dataModule.dataset("posts"); 
+}).subscribe();
+
+// Either way, the response will be an array
+insertQuery.subscribe(records => {
+     // you will always get an array of created records, including their generated IDs (even when inserting a single record)
+  },
+  error => {
+     // you can see the error info here, if something goes wrong
+});
+```
+
+### [Updating records](#updating-records)
+
+The `update` method is used to modify records, it always has to be used with the `.where` method and a filter criteria.
+
+```javascript
+const posts = dataModule.dataset("posts");
 
 posts
-  .update({ title: "Same title for tom and harry posts" }) 
+  .update({ title: "Same title for tom and harry posts" })
   .where(field => field("author_name").isInArray(["Tom", "Harry"]))
   .subscribe(affectedRecords => {
-   /* [{ title: "Same title for tom and harry posts", author_name: "Tom" },       
-       { title: "Same title for tom and harry posts", author_name: "Tom" },   
+   /* [{ title: "Same title for tom and harry posts", author_name: "Tom" },
+       { title: "Same title for tom and harry posts", author_name: "Tom" },
        { title: "Same title for tom and harry posts", author_name: "Harry" },
-       { title: "Same title for tom and harry posts", author_name: "Tom" }]   
+       { title: "Same title for tom and harry posts", author_name: "Tom" }]
     */
-  }); 
-```  
-  
-### [Deleting records](#deleting-records)  
- Deleting  also requires at least one condition: 
-  
-``` javascript  
+  });
+```
+
+### [Deleting records](#deleting-records)
+ Deleting  also requires at least one condition:
+
+``` javascript
 const posts = dataModule.dataset("posts");
 
 posts
   .delete()
   .where(field => field("title").isLike("%test%"))
-  .subscribe(deletedFields => {  
-    // you will be able to access the deleted posts here  
-    // they are not stored in the DB anymore, but maybe you 
+  .subscribe(deletedFields => {
+    // you will be able to access the deleted posts here
+    // they are not stored in the DB anymore, but maybe you
     // want to display a visual confirmation of what was deleted
-  });  
-```  
-  
-### [Query records](#dataset-query-objects)  
-  
+  });
+```
+
+### [Query records](#dataset-query-objects)
+
 Query object, returned by `select()` method, has an ability to filter, order, limit and offset records. These methods have to be called in chain before `subscribe()`.
-  
-### [Our first query: selecting all records in a dataset](#select-all-dataset-records)  
-    
-```javascript  
-const posts = dataModule.dataset("posts");  
+
+### [Our first query: selecting all records in a dataset](#select-all-dataset-records)
+
+```javascript
+const posts = dataModule.dataset("posts");
 
 posts.select()
   .subscribe(
-    records => { 
-      // here are all your posts 
+    records => {
+      // here are all your posts
     },
-    error => { 
-      // some error happened 
+    error => {
+      // some error happened
     }
-  );     
-```  
-  
-### [Sorting records](#sorting-records)  
-  
-In order to sort records, you need to call `.sortAsc` or `.sortDesc` on a `Query` object and pass the name of the field you want to sort by.  
-  
-```javascript  
+  );
+```
+
+### [Sorting records](#sorting-records)
+
+In order to sort records, you need to call `.sortAsc` or `.sortDesc` on a `Query` object and pass the name of the field you want to sort by.
+
+```javascript
 const posts = dataModule.dataset("posts");
 
 posts
   .select()
   .sortAsc("created_at")
-  .subscribe(records => { 
-    // you've got sorted records here 
+  .subscribe(records => {
+    // you've got sorted records here
   });
-```  
-  
-### [Limit and offset](#limit-offset)  
-  
-You can use `.limit` and `.offset` on a `Query` to paginate your records. They can be used separately or together. Only setting the limit (to a value X) will make the query operate on the first X records. Only setting the `offset` will make the query operate on the last Y records, starting from the `offset` value.  
-  
-```javascript  
+```
+
+### [Limit and offset](#limit-offset)
+
+You can use `.limit` and `.offset` on a `Query` to paginate your records. They can be used separately or together. Only setting the limit (to a value X) will make the query operate on the first X records. Only setting the `offset` will make the query operate on the last Y records, starting from the `offset` value.
+
+```javascript
 const posts = dataModule.dataset("posts");
 
 posts.select()
   .limit(2)
   .offset(5)
   .subscribe(records => // paginatedPosts will be an array of 2 records, starting from position 5);
-```  
-  
-### [Only retrieving certain fields](#retrieve-certain-fields)  
-  
-You can use `.fields` method to restrict fields you want to retrieve.  
-  
+```
+
+### [Only retrieving certain fields](#retrieve-certain-fields)
+
+You can use `.fields` method to restrict fields you want to retrieve.
+
 ```javascript
 const posts = dataModule.dataset("posts");
 
 posts.select()
-  .fields("title", "author") // you can also pass an array of field names 
+  .fields("title", "author") // you can also pass an array of field names
   .subscribe(records => // you will get array of {id, title, author} records (id is always returned));
-``` 
+```
 
 ### [Aggregation functions](#aggregation-function)
 
@@ -201,14 +201,23 @@ posts.select()
        }]
      */
   });
-``` 
+```
 
-The full list of available aggregation functions:
-* max
-* min
-* sum
-* avg
-* count
+You can provide an alias to make result more readable (using aliases is the only way to get proper results if you want to query two or more the same aggregation functions in one query):
+
+```javascript
+const posts = dataModule.dataset("posts");
+
+posts.select()
+  .fields({ fn: "max", field: "likes": alias: "likes" })
+  .subscribe(result => {
+    /* the result is:
+       [
+         { "likes": 24 },
+       ]
+     */
+  });
+```
 
 You can also use any sets of plain fields and functions. Let's calculate the maximum of likes each author has received:
 ```javascript
@@ -224,62 +233,69 @@ posts.select()
        ]
      */
   });
-``` 
+```
 
-  
-### [Filtering records](#filtering-records)  
-  
-You can use the filtering to select what records a certain query will operate on.  
-  
-In order to define a filter, you can use the exposed method `field`.  
-  
+The full list of available aggregation functions:
+* max
+* min
+* sum
+* avg
+* count
+
+
+### [Filtering records](#filtering-records)
+
+You can use the filtering to select what records a certain query will operate on.
+
+In order to define a filter, you can use the exposed method `field`.
+
 ```javascript
-import { field } from "jexia-sdk-js/node";  
-  
-const isAuthorTom = field("author_name").isEqualTo("Tom");  
-const isAuthorDick = field("author_name").isEqualTo("Dick");  
-const isAuthorTomOrDick = isAuthorTom.or(isAuthorDick);  
-  
-// In order to use these conditions, they need to be added to a query through `.where` method  
-  
-dataModule.dataset("posts")  
+import { field } from "jexia-sdk-js/node";
+
+const isAuthorTom = field("author_name").isEqualTo("Tom");
+const isAuthorDick = field("author_name").isEqualTo("Dick");
+const isAuthorTomOrDick = isAuthorTom.or(isAuthorDick);
+
+// In order to use these conditions, they need to be added to a query through `.where` method
+
+dataModule.dataset("posts")
  .select()
  .where(isAuthorTomOrDick)
- .subscribe(records => // posts of Tom and Dick);  
-```  
-  
-If you prefer, `.where` method also accepts a lazy callback, that receives the `field` method received as an argument:  
-  
-```javascript  
-dataModule.dataset("posts")  
- .select() 
- .where(field => field("author_name").isEqualTo("Harry"));  
-```  
-  
-Multiple `.where` calls can be chained, but only the last call will be taken into account. If a complex condition needs to be set for filtering, it has to be created in one go (in-line or not) and passed as an argument to the `.where` method.  
-  
-Filtering conditions can be nested at any level.  
-  
-```javascript  
-// Filtering in a flat way  
-const isPostedByTomAndIsAboutSports = field("author_name")  
- .isEqualTo("Tom").and(field("title").isLike("sports"));  
- 
-// Filtering with one nested level  
-const isPostedByDickAndIsAboutMusic = field("author_name")  
- .isEqualTo("Dick").and(field("title").isLike("music"));  
- 
-const isTomOrIsDickHarry = field("author_name")  
- .isEqualTo("Tom").or( isPostedByDickAndIsAboutMusic // nested level );  
- 
-// Filtering with multiple nested levels  
-const isAuthorDutch = field("author_country").isEqualTo("NL");  
-const isKidOrSenior = field("author_age")  
- .isGreaterThan(64).or(field("author_age").isLessThan(16));  
-const isTomAndIsDuthOrKidOrSenior = field("first_name")  
+ .subscribe(records => // posts of Tom and Dick);
+```
+
+If you prefer, `.where` method also accepts a lazy callback, that receives the `field` method received as an argument:
+
+```javascript
+dataModule.dataset("posts")
+ .select()
+ .where(field => field("author_name").isEqualTo("Harry"));
+```
+
+Multiple `.where` calls can be chained, but only the last call will be taken into account. If a complex condition needs to be set for filtering, it has to be created in one go (in-line or not) and passed as an argument to the `.where` method.
+
+Filtering conditions can be nested at any level.
+
+```javascript
+// Filtering in a flat way
+const isPostedByTomAndIsAboutSports = field("author_name")
+ .isEqualTo("Tom").and(field("title").isLike("sports"));
+
+// Filtering with one nested level
+const isPostedByDickAndIsAboutMusic = field("author_name")
+ .isEqualTo("Dick").and(field("title").isLike("music"));
+
+const isTomOrIsDickHarry = field("author_name")
+ .isEqualTo("Tom").or( isPostedByDickAndIsAboutMusic // nested level );
+
+// Filtering with multiple nested levels
+const isAuthorDutch = field("author_country").isEqualTo("NL");
+const isKidOrSenior = field("author_age")
+ .isGreaterThan(64).or(field("author_age").isLessThan(16));
+const isTomAndIsDuthOrKidOrSenior = field("first_name")
  .isEqualTo("Tom").and( isAuthorDutch.or(isKidOrSenior) );
-```  
-  
-### [Filtering operator list and examples](#filtering-operator-list)  
-  
+```
+
+### [Filtering operator list and examples](#filtering-operator-list)
+
 You can find a complete list of the operators supported for filtering in the [FieldFilter API reference](../classes/FieldFilter.html).

--- a/src/internal/query.ts
+++ b/src/internal/query.ts
@@ -19,6 +19,7 @@ type KeyOfObject<T> = Extract<keyof T, string>;
 export interface IAggField<T = any> {
   fn: "count" | "min" | "max" | "avg" | "sum";
   col: KeyOfObject<T> | "*";
+  alias?: string;
 }
 
 export interface ICompiledAggField {
@@ -169,6 +170,6 @@ export class Query<T = any> {
     } else if (agg.col === "*") {
       throw new Error(`Field name should be provided with the ${agg.fn}() function`);
     }
-    return { [agg.fn]: `${agg.fn}(${agg.col})` };
+    return { [agg.alias || agg.fn]: `${agg.fn}(${agg.col})` };
   }
 }


### PR DESCRIPTION
Add an alias to aggregation functions:

before:
```
posts.select()
  .fields("author", { fn: "max", field: "likes" })
  .subscribe(result => {
    /* the result is:
       [
         { author: "Tom", "max": 10 },
         { author: "Harry", "max": 24 },
       ]
     */
  });
```
after:
```
posts.select()
  .fields("author", { fn: "max", field: "likes": alias: "max likes" })
  .subscribe(result => {
    /* the result is:
       [
         { author: "Tom", "max likes": 10 },
         { author: "Harry", "max likes": 24 },
       ]
     */
  });
```