### PR TITLE
feat(select-query): add fields as a select query argument

### DIFF
--- a/src/api/core/queries/baseQuery.ts
+++ b/src/api/core/queries/baseQuery.ts
@@ -19,7 +19,7 @@ export abstract class BaseQuery<T, D extends T = any> extends Observable<T[]> {
   /**
    * @internal
    */
-  protected query: Query<T>;
+  protected query = new Query<T>();
   /**
    * Body of request
    * @returns T | T[]
@@ -35,8 +35,6 @@ export abstract class BaseQuery<T, D extends T = any> extends Observable<T[]> {
     super((subscriber) =>
       this.queryExecuter.executeRequest(this.compiledRequest).subscribe(subscriber),
     );
-
-    this.query = new Query<T>();
   }
 
   /**
@@ -49,7 +47,7 @@ export abstract class BaseQuery<T, D extends T = any> extends Observable<T[]> {
   public fields(...fields: Array<Extract<keyof T, string> | IAggField<T>>): this;
   public fields<K extends Extract<keyof T, string>>(field: K | IAggField<T>,
                                                     ...fields: Array<K | IAggField<T>>): this {
-    this.query.fields = Array.isArray(field) ? field : [field, ...fields];
+    this.query.fields = this.query.fields.concat(Array.isArray(field) ? field : [field, ...fields]);
     return this;
   }
 

--- a/src/api/core/queries/selectQuery.spec.ts
+++ b/src/api/core/queries/selectQuery.spec.ts
@@ -21,6 +21,7 @@ describe("SelectQuery class", () => {
 
     if (mockQuery) {
       queryMock = createMockFor(Query);
+      queryMock.fields = [];
       subject["query"] = queryMock;
     }
     return {

--- a/src/api/dataops/dataset.spec.ts
+++ b/src/api/dataops/dataset.spec.ts
@@ -35,6 +35,12 @@ describe("Dataset class", () => {
     expect(dataset.select() instanceof SelectQuery).toBeTruthy();
   });
 
+  it("should start a select query with provided fields", () => {
+    const dataset = new Dataset("test", createMockFor(RequestExecuter));
+    const selectQuery = dataset.select("field1", "field2");
+    expect((selectQuery as any).query.fields).toEqual(["field1", "field2"]);
+  });
+
   it("should be able start a update query", () => {
     const dataset = new Dataset("test", createMockFor(RequestExecuter));
     expect(dataset.update({}) instanceof UpdateQuery).toBeTruthy();

--- a/src/api/dataops/dataset.ts
+++ b/src/api/dataops/dataset.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from "injection-js";
+import { IAggField } from "../../internal/query";
 import { RequestExecuter } from "../../internal/executer";
 import { QueryActionType } from "../../internal/utils";
 import { IFilteringCriterion, IFilteringCriterionCallback } from "../core/filteringApi";
@@ -64,8 +65,9 @@ export class Dataset<
    * @returns Query object specialized for select statements.
    * With no filters set, returns all records in the selected dataset.
    */
-  public select(): SelectQuery<D> {
-    return new SelectQuery<D>(this.requestExecuter, ResourceType.Dataset, this.datasetName);
+  public select(...fields: Array<Extract<keyof T, string> | IAggField<T>>): SelectQuery<D> {
+    return new SelectQuery<D>(this.requestExecuter, this.resourceType, this.datasetName)
+      .fields(fields);
   }
 
   /**


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

`dataset.select()` method does not have arguments, in order to select certain fields `fields()` method should be called.

Issue Number: N/A

## What is the new behavior?
Fields can be provided as an argument to `dataset.select()` function:
```
dataset.select("user", "comments").subescribe();
```
this code is equal to the following:
```
dataset.select().fields("user", "comments").subescribe();
```

Both approaches can be used simultaneously.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
JEXIA-3553
