### PR TITLE
fix(rtc): wrong url when using projectURL config param

### DIFF
--- a/e2e/teardowns.ts
+++ b/e2e/teardowns.ts
@@ -52,7 +52,7 @@ export const init = async (
   loadRtc = false) => {
   const modules: IModule[] = [
     dom,
-    ...(loadRtc ? [rtm] : null),
+    ...(loadRtc ? [rtm] : []),
     ErrorLoggerModule,
   ];
 
@@ -115,7 +115,7 @@ export const initWithUMS = async () => {
   client = await jexiaClient().init({
     projectID: process.env.E2E_PROJECT_ID as string,
     zone: process.env.E2E_PROJECT_ZONE as string,
-  }, ums, dom, new LoggerModule(LogLevel.ERROR)); // Change to LogLevel.DEBUG to have more logs
+  }, ums, dom, ErrorLoggerModule); // Change to LogLevel.DEBUG to have more logs
 };
 
 export const initWithJFS = async (filesetName: string = "testFileset",

--- a/src/config/config.spec.ts
+++ b/src/config/config.spec.ts
@@ -1,48 +1,40 @@
 import * as faker from "faker";
 import { IAuthOptions } from "../api/core/tokenManager";
-import { API, API_SUFFIX, DEFAULT_PROJECT_ZONE, getApiUrl } from "./config";
+import {
+  API,
+  API_SUFFIX,
+  DEFAULT_PROJECT_ZONE,
+  getApiUrl,
+  stripUrlSlashes,
+  getRtcUrl,
+  REALTIME_SUFFIX,
+  getZone,
+} from "./config";
+
+const createAuthOptions = ({
+  projectID = faker.random.uuid(),
+  zone = faker.helpers.randomize(["nl00", "nl01", "nl03"]) as string | null,
+  projectURL = null as string | null,
+  config = { projectID, zone, projectURL } as IAuthOptions,
+} = {}) => config;
 
 describe("get api url", () => {
-  const createAuthOptions = ({
-    projectID = faker.random.uuid(),
-    zone = faker.helpers.randomize(["NL00", "NL01", "NL03"]) as string | null,
-    projectURL = null as string | null,
-    config = { projectID, zone, projectURL } as IAuthOptions,
-  } = {}) => {
-    return config;
-  };
-
   it("should return composed url", () => {
     const authOptions = createAuthOptions();
 
-    expect(getApiUrl(authOptions)).toEqual(
-      API.PROTOCOL
-      + "://"
-      + authOptions.projectID
-      + "."
-      + authOptions.zone
-      + "."
-      + API_SUFFIX,
-    );
+    expect(getApiUrl(authOptions)).toEqual([
+      API.PROTOCOL,
+      authOptions.projectID + ".",
+      getZone(authOptions.zone) + ".",
+      API_SUFFIX,
+    ].join(""));
   });
 
   it("should return given project URL when provided", () => {
     const projectURL = faker.internet.url();
     const authOptions = createAuthOptions({ projectURL });
 
-    expect(getApiUrl(authOptions)).toEqual(projectURL);
-  });
-
-  it("should return url with given zone", () => {
-    const authOptions = createAuthOptions();
-
-    expect(getApiUrl(authOptions)).toContain("." + authOptions.zone);
-  });
-
-  it(`should return url with default zone when given zone is undefined`, () => {
-    const authOptions = { projectID: faker.random.uuid() };
-
-    expect(getApiUrl(authOptions)).toContain("." + DEFAULT_PROJECT_ZONE);
+    expect(getApiUrl(authOptions)).toEqual(stripUrlSlashes(projectURL));
   });
 
   ["", null].forEach((zone) => {
@@ -50,6 +42,84 @@ describe("get api url", () => {
       const authOptions = createAuthOptions({ zone });
 
       expect(getApiUrl(authOptions)).toContain("." + DEFAULT_PROJECT_ZONE);
+    });
+  });
+});
+
+describe("get rtc url", () => {
+  const generateToken = () => {
+    const token = faker.random.alphaNumeric(36);
+    return { token, expectedParam: `?access_token=${token}` };
+  };
+
+  it("should return composed url", () => {
+    const authOptions = createAuthOptions();
+    const { token, expectedParam } = generateToken();
+
+    expect(getRtcUrl(authOptions, token)).toEqual([
+      API.REAL_TIME.PROTOCOL,
+      authOptions.projectID + ".",
+      getZone(authOptions.zone) + ".",
+      REALTIME_SUFFIX,
+      expectedParam,
+    ].join(""));
+  });
+
+  it("should return given project URL formatted", () => {
+    const domain = faker.internet.domainName();
+    const projectURL = `${faker.internet.protocol()}://${domain}`;
+    const authOptions = createAuthOptions({ projectURL });
+    const { token, expectedParam } = generateToken();
+
+    expect(getRtcUrl(authOptions, token)).toEqual([
+      API.REAL_TIME.PROTOCOL,
+      domain,
+      API.REAL_TIME.ENDPOINT,
+      expectedParam,
+    ].join(""));
+  });
+
+  ["", null].forEach((zone) => {
+    it(`should return url with default zone when given zone is "${zone}"`, () => {
+      const authOptions = createAuthOptions({ zone });
+      const { token } = generateToken();
+
+      expect(getRtcUrl(authOptions, token)).toContain("." + DEFAULT_PROJECT_ZONE);
+    });
+  });
+});
+
+describe("get zone", () => {
+  it("should return given zone when isn't nullish", () => {
+    const zone = faker.random.word();
+
+    expect(getZone(zone)).toEqual(zone);
+  });
+
+  [undefined, null, ""].forEach((zone) => {
+    it(`should return default zone when provided one is "${zone}"`, () => {
+      expect(getZone(zone)).toEqual(DEFAULT_PROJECT_ZONE);
+    });
+  });
+});
+
+describe("strip url slashes", () => {
+  it("should return given project URL without changes when it doesn't contain slashes", () => {
+    const projectURL = faker.internet.url();
+
+    expect(stripUrlSlashes(projectURL)).toEqual(projectURL);
+  });
+
+  it("should strip trailling slashes", () => {
+    const projectURL = faker.internet.url();
+    const times = faker.random.number({ min: 1, max: 10 });
+
+    expect(stripUrlSlashes(projectURL + "/".repeat(times))).toEqual(projectURL);
+  });
+
+  [undefined, null, ""].forEach((url) => {
+    it(`should return empty string when url is "${url}"`, () => {
+      expect(stripUrlSlashes(url)).toEqual("");
     });
   });
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -11,8 +11,7 @@ export const API = {
   },
   REAL_TIME: {
     ENDPOINT: "/rtc",
-    PORT: "",
-    PROTOCOL: "wss",
+    PROTOCOL: "wss://",
   },
   UMS: {
     ENDPOINT: "ums",
@@ -27,7 +26,7 @@ export const API = {
   DOMAIN: "com",
   HOST: "app.jexia",
   PORT: 443,
-  PROTOCOL: "https",
+  PROTOCOL: "https://",
 };
 
 /* default refresh token interval: 1 hour and 50 minutes; JEXIA tokens expire in 2 hours */
@@ -44,8 +43,55 @@ export const DEFAULT_PROJECT_ZONE = "nl00";
 export const API_SUFFIX = `${API.HOST}.${API.DOMAIN}:${API.PORT}`;
 
 /**
+ * Suffix of Real time url: host.domain:port
+ */
+export const REALTIME_SUFFIX = `${API.HOST}.${API.DOMAIN}${API.REAL_TIME.ENDPOINT}`;
+
+/**
+ * Strips trailling slashes at the end of an URL
+ */
+export function stripUrlSlashes(url: string | null | undefined): string {
+  return (url || "").replace(/\/+$/, "");
+}
+
+/**
+ * Fallback to default zone when zone isn't provided
+ */
+export function getZone(zone: string | null | undefined): string {
+  return zone || DEFAULT_PROJECT_ZONE;
+}
+
+/**
  * Gets the composed API URL of a given project
  */
 export function getApiUrl({ projectID, zone, projectURL }: IAuthOptions): string {
-  return projectURL || `${API.PROTOCOL}://${projectID}.${zone || DEFAULT_PROJECT_ZONE}.${API_SUFFIX}`;
+  return stripUrlSlashes(projectURL) || [
+    API.PROTOCOL,
+    projectID,
+    `.${getZone(zone)}.`,
+    API_SUFFIX,
+  ].join("");
+}
+
+/**
+ * Gets the composed URL of a given project for RTC Module
+ */
+export function getRtcUrl({ projectID, zone, projectURL }: IAuthOptions, token: string): string {
+  const tokenParam = `?access_token=${token}`;
+
+  if (projectURL) {
+    return [
+      stripUrlSlashes(projectURL).replace(/^https?:\/\//i, API.REAL_TIME.PROTOCOL),
+      API.REAL_TIME.ENDPOINT,
+      tokenParam,
+    ].join("");
+  }
+
+  return [
+    API.REAL_TIME.PROTOCOL,
+    projectID,
+    `.${getZone(zone)}.`,
+    REALTIME_SUFFIX,
+    tokenParam,
+  ].join("");
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently when user pass `projectURL` only, RTC url is wrongly formatted.

## What is the new behavior?
WS url follows the same rules and of api urls.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```

