### PR TITLE
refactor(request-executer): extract method that parses query params

### DIFF
--- a/src/internal/executer.ts
+++ b/src/internal/executer.ts
@@ -5,7 +5,7 @@ import { ClientInit } from "../api/core/client";
 import { ResourceEndpoint } from "../api/core/resource";
 import { AuthOptions, IAuthOptions, TokenManager } from "../api/core/tokenManager";
 import { getApiUrl } from "../config";
-import { QueryParam } from "../internal/utils";
+import { parseQueryParams } from "../internal/utils";
 import { IRequestExecuterData } from "./executer.interfaces";
 import { IRequestOptions, RequestAdapter, RequestMethod } from "./requestAdapter";
 
@@ -19,7 +19,7 @@ export class RequestExecuter {
   ) { }
 
   public executeRequest<T = any>(request: IRequestExecuterData): Observable<T> {
-    const URI = this.getUrl(request) + this.parseQueryParams(request);
+    const URI = this.getUrl(request) + parseQueryParams(request.queryParams);
 
     return combineLatest([
       from(this.systemInit),
@@ -48,27 +48,6 @@ export class RequestExecuter {
 
   private hasBody({ method }: IRequestExecuterData): boolean {
     return ![RequestMethod.GET, RequestMethod.DELETE].includes(method);
-  }
-
-  /**
-   * Parses query params elements into query string format
-   *
-   * @param  queryParams
-   * @returns string
-   */
-  private parseQueryParams({ queryParams = [] }: IRequestExecuterData): string {
-    if (!queryParams.length) {
-      return "";
-    }
-
-    const encodeValue = (v: any) => encodeURIComponent(
-      typeof v === "string" ? v : JSON.stringify(v)
-    );
-    const toQueryParam = ({ key, value }: QueryParam) => `${key}=${encodeValue(value)}`;
-
-    return "?" + queryParams
-      .map(toQueryParam)
-      .join("&");
   }
 
   private getUrl({ resourceType, resourceName }: IRequestExecuterData): string {

--- a/src/internal/utils/queryParam.spec.ts
+++ b/src/internal/utils/queryParam.spec.ts
@@ -1,0 +1,58 @@
+import * as faker from "faker";
+import { parseQueryParams } from "./queryParam";
+
+describe("parseQueryParams method", () => {
+  it("should return empty string when argument is empty", () => {
+    expect(parseQueryParams(undefined)).toBe("");
+  });
+
+  it("should parse to the correct format for non-string values", () => {
+    const key = faker.random.word();
+    const value = faker.helpers.randomize([
+      [],
+      faker.random.number(),
+      {},
+      faker.random.boolean(),
+    ]);
+
+    const queryParams = [
+      { key, value },
+    ];
+
+    const encodeValue = (v: any) => encodeURIComponent(JSON.stringify(v));
+    const expectedParams = `?${key}=${encodeValue(value)}`;
+
+    expect(parseQueryParams(queryParams)).toEqual(expectedParams);
+  });
+
+  it("should parse to the correct format for string values", () => {
+    const key = faker.random.word();
+    const value = faker.random.words();
+
+    const queryParams = [
+      { key, value },
+    ];
+
+    const encodeValue = (v: any) => encodeURIComponent(v);
+
+    const expectedParams = `?${key}=${encodeValue(value)}`;
+
+    expect(parseQueryParams(queryParams)).toEqual(expectedParams);
+  });
+
+  it("should separate params by ampersand", () => {
+    const key1 = faker.random.word();
+    const key2 = faker.random.word();
+    const key3 = faker.random.word();
+
+    const queryParams = [
+      { key: key1, value: faker.random.number() },
+      { key: key2, value: faker.random.number() },
+      { key: key3, value: faker.random.number() },
+    ];
+
+    const result: string = parseQueryParams(queryParams);
+
+    expect(result.split("&").length).toEqual(queryParams.length);
+  });
+});

--- a/src/internal/utils/queryParam.ts
+++ b/src/internal/utils/queryParam.ts
@@ -1,5 +1,10 @@
 export type QueryParam = { key: string; value: any; };
 
+const encodeValue = (v: any) => encodeURIComponent(
+  typeof v === "string" ? v : JSON.stringify(v)
+);
+const toQueryParam = ({ key, value }: QueryParam) => `${key}=${encodeValue(value)}`;
+
 /**
  * Maps an object into a list of QueryParam
  * @param   o The object to be mapped
@@ -7,4 +12,20 @@ export type QueryParam = { key: string; value: any; };
  */
 export function toQueryParams(o: object): QueryParam[] {
   return Object.entries(o).map(([key, value]) => ({ key, value }));
+}
+
+/**
+ * Parses query params elements into query string format
+ *
+ * @param  queryParams
+ * @returns string
+ */
+export function parseQueryParams(queryParams: QueryParam[] = []): string {
+  if (queryParams && !queryParams.length) {
+    return "";
+  }
+
+  return "?" + queryParams
+    .map(toQueryParam)
+    .join("&");
 }


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Current method that parses query params object it's inside `RequestExecuter` class.

## What is the new behavior?
function was extracted and can be imported anywhere

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```