### PR TITLE
fix(token-manager): throw http status when it occurs

### DIFF
--- a/src/api/core/tokenManager.ts
+++ b/src/api/core/tokenManager.ts
@@ -1,7 +1,7 @@
 import { Injectable, InjectionToken } from "injection-js";
 import { from, Observable } from "rxjs";
 import { catchError, map, tap } from "rxjs/operators";
-import { API, DELAY, MESSAGE, getApiUrl } from "../../config";
+import { API, DELAY, MESSAGE, getApiUrl, getProjectId } from "../../config";
 import { IRequestError, RequestAdapter, RequestMethod } from "../../internal/requestAdapter";
 import { Logger } from "../logger/logger";
 import { TokenStorage } from "./componentStorage";
@@ -254,7 +254,10 @@ export class TokenManager {
       tap((refreshedTokens: Tokens) => resolve(refreshedTokens.access_token)),
       catchError((error: IRequestError) => {
         delete this.defers[auth];
-        throw new Error(this.getErrorMessage(error));
+        throw {
+          httpStatus: error.httpStatus,
+          message: this.getErrorMessage(error),
+        };
       }),
     );
   }
@@ -285,7 +288,7 @@ export class TokenManager {
 
   public getErrorMessage({ httpStatus: { code, status } }: IRequestError): string {
     if (code === 404) {
-      return `Authorization failed: project ${this.config.projectID} not found.`;
+      return `Authorization failed: project ${getProjectId(this.config)} not found.`;
     }
     return `Authorization failed: ${code} ${status}`;
   }

--- a/src/config/config.spec.ts
+++ b/src/config/config.spec.ts
@@ -9,6 +9,7 @@ import {
   getRtcUrl,
   REALTIME_SUFFIX,
   getZone,
+  getProjectId,
 } from "./config";
 
 const createAuthOptions = ({
@@ -121,5 +122,33 @@ describe("strip url slashes", () => {
     it(`should return empty string when url is "${url}"`, () => {
       expect(stripUrlSlashes(url)).toEqual("");
     });
+  });
+});
+
+describe("get project id", () => {
+  it("should return project id when config object has it", () => {
+    const config = {
+      projectID: faker.random.uuid(),
+      projectURL: faker.internet.url(),
+    };
+
+    expect(getProjectId(config)).toEqual(config.projectID);
+  });
+
+  it("should get id from URL when id is not provided", () => {
+    const projectID = faker.random.uuid();
+    const config = {
+      projectURL: `https://${projectID}.com`,
+    };
+
+    expect(getProjectId(config)).toEqual(projectID);
+  });
+
+  it("should return empty string when there is no id in URL", () => {
+    const config = {
+      projectURL: faker.internet.url(),
+    };
+
+    expect(getProjectId(config)).toEqual("");
   });
 });

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -95,3 +95,20 @@ export function getRtcUrl({ projectID, zone, projectURL }: IAuthOptions, token: 
     tokenParam,
   ].join("");
 }
+
+/**
+ * Gets the project id from the url or empty if it's not found
+ */
+function getProjectIdFromUrl(projectURL?: string | null): string {
+  const uuidRegex = /[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}/i;
+  const match = (projectURL || "").match(uuidRegex);
+
+  return match ? match[0] : "";
+}
+
+/**
+ * Gets the projectID from the config
+ */
+export function getProjectId({ projectID, projectURL }: Pick<IAuthOptions, "projectID" | "projectURL">): string {
+  return projectID || getProjectIdFromUrl(projectURL);
+}


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [X] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently when some authentication error is thrown, there is no http status code for the user, just a plain message.

Issue Number: #180 

## What is the new behavior?
`httpStatus` object is included in the error, with `code` and `statusText` available.

## Does this PR introduce a breaking change?

```
[ ] Yes
[X] No
```
