### PR TITLE
fix(token): timeout for refreshing token based on expiration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9261,6 +9261,11 @@
         "verror": "1.10.0"
       }
     },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
   "dependencies": {
     "form-data": "^2.3.3",
     "injection-js": "^2.3.0",
+    "jwt-decode": "^3.1.2",
     "node-fetch": "^2.6.0",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^6.5.5",

--- a/src/api/core/tokenManager.spec.ts
+++ b/src/api/core/tokenManager.spec.ts
@@ -152,18 +152,18 @@ describe("TokenManager", () => {
     });
 
     it("should schedule token refreshing when authorization is succeeded", async () => {
-      const { subject, validOptions } = createSubject();
+      const { subject, validOptions, tokens } = createSubject();
       jest.spyOn(subject as any, "startRefreshDigest");
       await subject.init(validOptions);
-      expect((subject as any).startRefreshDigest).toHaveBeenCalledWith(["apikey"]);
+      expect((subject as any).startRefreshDigest).toHaveBeenCalledWith(["apikey"], tokens.access_token);
     });
 
     it("should schedule token refreshing for the authentication by alias", async () => {
-      const { subject, validOptions } = createSubject();
+      const { subject, validOptions, tokens } = createSubject();
       const auth = faker.random.word();
       jest.spyOn(subject as any, "startRefreshDigest");
       await subject.init({ ...validOptions, auth });
-      expect((subject as any).startRefreshDigest).toHaveBeenCalledWith([auth]);
+      expect((subject as any).startRefreshDigest).toHaveBeenCalledWith([auth], tokens.access_token);
     });
 
     describe("get error message", () => {
@@ -310,22 +310,22 @@ describe("TokenManager", () => {
       clear();
     });
 
-    it("should clear all refreshing intervals", async () => {
+    it("should clear all refreshing timeouts", async () => {
       const { subject, validOptions } = createSubject();
-      const clearIntervalSpy = jest.spyOn(global, "clearInterval");
+      const clearTimeoutSpy = jest.spyOn(global, "clearTimeout");
       await subject.init(validOptions);
       await subject.addTokens([faker.random.word()], {
         access_token: faker.random.word(),
         refresh_token: faker.random.word(),
       });
-      const [ firstInterval, secondInterval ] = (subject as any).refreshes;
+      const [ firstTimeout, secondTimeout ] = (subject as any).refreshes;
       await subject.terminate();
       // @ts-ignore
-      expect(global.clearInterval).toHaveBeenNthCalledWith(1, firstInterval);
+      expect(global.clearTimeout).toHaveBeenNthCalledWith(1, firstTimeout);
       // @ts-ignore
-      expect(global.clearInterval).toHaveBeenNthCalledWith(2, secondInterval);
+      expect(global.clearTimeout).toHaveBeenNthCalledWith(2, secondTimeout);
       expect((subject as any).refreshes).toEqual([]);
-      clearIntervalSpy.mockRestore();
+      clearTimeoutSpy.mockRestore();
     });
 
     it("should throw an error if the token is accessed after terminate", async (done) => {

--- a/src/api/core/tokenManager.ts
+++ b/src/api/core/tokenManager.ts
@@ -3,7 +3,7 @@ import { from, Observable } from "rxjs";
 import { catchError, map, tap } from "rxjs/operators";
 import { API, MESSAGE, getApiUrl, getProjectId } from "../../config";
 import { IRequestError, RequestAdapter, RequestMethod } from "../../internal/requestAdapter";
-import { untilTokenExpired } from "../../internal/utils";
+import { delayTokenRefresh } from "../../internal/utils";
 import { Logger } from "../logger/logger";
 import { TokenStorage } from "./componentStorage";
 
@@ -198,14 +198,7 @@ export class TokenManager {
    * @ignore
    */
   private startRefreshDigest(aliases: string[], accessToken: string) {
-    const tokenExpired = untilTokenExpired(accessToken);
-    const subtractDelay = 60 * 10000; // subtract 10m in ms from the delay
-    let delay = tokenExpired - subtractDelay;
-
-    // make sure we have a positive delay
-    if (delay < 0) {
-      delay = 0
-    }
+    const delay = delayTokenRefresh(accessToken)
 
     this.refreshes.push(
       setTimeout(() => {

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -33,9 +33,6 @@ export const API = {
   PROTOCOL: "https://",
 };
 
-/* default refresh token interval: 1 hour and 50 minutes; JEXIA tokens expire in 2 hours */
-export const DELAY = 1000 * 60 * 110;
-
 /**
  * The default project zone
  */

--- a/src/internal/utils/index.ts
+++ b/src/internal/utils/index.ts
@@ -29,3 +29,4 @@ export function clone<T>(o: T): T {
 
 export * from "./queryActionType";
 export * from "./queryParam";
+export * from "./token";

--- a/src/internal/utils/token.spec.ts
+++ b/src/internal/utils/token.spec.ts
@@ -1,0 +1,16 @@
+import { untilTokenExpired } from "./token";
+
+const expiredToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXN0IFRva2VuIiwiaWF0Ijo5NzYyODUzMDQsImV4cCI6OTc2Mjg1MzA0LCJhdWQiOiJ3d3cuamV4aWEuY29tIiwic3ViIjoiam9obkBkb2UuY29tIn0.RkxTdiuiIvwvOIVBVqMJt6hpiobz7_FG0aKyE686eE0";
+const futureToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXN0IFRva2VuIiwiaWF0Ijo2NDA5MDE4OTMwNCwiZXhwIjo2NDA5MDE4OTMwNCwiYXVkIjoid3d3LmpleGlhLmNvbSIsInN1YiI6ImpvaG5AZG9lLmNvbSJ9.qXp8xLcaA0RrnVg097K49p6FGax5HQAQ8NcutpKpA0w";
+
+describe("getting time until token expired", () => {
+  it("should return '0' when the token got expired", () => {
+    const time = untilTokenExpired(expiredToken)
+    expect(time).toBe(0);
+  });
+
+  it("should return time until the token got expired", () => {
+    const time = untilTokenExpired(futureToken);
+    expect(time).toBeGreaterThan(0);
+  });
+});

--- a/src/internal/utils/token.spec.ts
+++ b/src/internal/utils/token.spec.ts
@@ -1,6 +1,8 @@
 import { untilTokenExpired } from "./token";
 
+// Set to the year 2000
 const expiredToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXN0IFRva2VuIiwiaWF0Ijo5NzYyODUzMDQsImV4cCI6OTc2Mjg1MzA0LCJhdWQiOiJ3d3cuamV4aWEuY29tIiwic3ViIjoiam9obkBkb2UuY29tIn0.RkxTdiuiIvwvOIVBVqMJt6hpiobz7_FG0aKyE686eE0";
+// Set to the year 4000
 const futureToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXN0IFRva2VuIiwiaWF0Ijo2NDA5MDE4OTMwNCwiZXhwIjo2NDA5MDE4OTMwNCwiYXVkIjoid3d3LmpleGlhLmNvbSIsInN1YiI6ImpvaG5AZG9lLmNvbSJ9.qXp8xLcaA0RrnVg097K49p6FGax5HQAQ8NcutpKpA0w";
 
 describe("getting time until token expired", () => {

--- a/src/internal/utils/token.spec.ts
+++ b/src/internal/utils/token.spec.ts
@@ -1,18 +1,32 @@
-import { untilTokenExpired } from "./token";
+import { untilTokenExpired, delayTokenRefresh } from "./token";
 
 // Set to the year 2000
 const expiredToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXN0IFRva2VuIiwiaWF0Ijo5NzYyODUzMDQsImV4cCI6OTc2Mjg1MzA0LCJhdWQiOiJ3d3cuamV4aWEuY29tIiwic3ViIjoiam9obkBkb2UuY29tIn0.RkxTdiuiIvwvOIVBVqMJt6hpiobz7_FG0aKyE686eE0";
 // Set to the year 4000
 const futureToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXN0IFRva2VuIiwiaWF0Ijo2NDA5MDE4OTMwNCwiZXhwIjo2NDA5MDE4OTMwNCwiYXVkIjoid3d3LmpleGlhLmNvbSIsInN1YiI6ImpvaG5AZG9lLmNvbSJ9.qXp8xLcaA0RrnVg097K49p6FGax5HQAQ8NcutpKpA0w";
 
-describe("getting time until token expired", () => {
-  it("should return '0' when the token got expired", () => {
-    const time = untilTokenExpired(expiredToken)
-    expect(time).toBe(0);
+describe("Token utils", () => {
+  describe("getting time until token expired", () => {
+    it("should return '0' when the token got expired", () => {
+      const time = untilTokenExpired(expiredToken)
+      expect(time).toBe(0);
+    });
+
+    it("should return time until the token got expired", () => {
+      const time = untilTokenExpired(futureToken);
+      expect(time).toBeGreaterThan(0);
+    });
   });
 
-  it("should return time until the token got expired", () => {
-    const time = untilTokenExpired(futureToken);
-    expect(time).toBeGreaterThan(0);
+  describe("calculating time for delay", () => {
+    it("should return '0' when the token got expired", () => {
+      const time = delayTokenRefresh(expiredToken)
+      expect(time).toBe(0);
+    });
+
+    it("should return time until the token got expired", () => {
+      const time = delayTokenRefresh(futureToken);
+      expect(time).toBeGreaterThan(0);
+    });
   });
 });

--- a/src/internal/utils/token.ts
+++ b/src/internal/utils/token.ts
@@ -1,5 +1,9 @@
 import jwt_decode from "jwt-decode";
 
+/**
+ * Calculate the expiration time until a token expired
+ * @internal
+ */
 export function untilTokenExpired(accessToken: string): number {
   try {
     const { exp: expired } = jwt_decode<{ exp: number }>(accessToken);
@@ -18,4 +22,19 @@ export function untilTokenExpired(accessToken: string): number {
   } catch (e) {
     return 0;
   }
+}
+
+/**
+ * Calculate the delay when refreshing a token via a timer
+ * @internal
+ */
+export function delayTokenRefresh(accessToken: string): number {
+  const tokenExpired = untilTokenExpired(accessToken);
+  const threshold = 60 * 10000; // 10m in ms
+
+  // if the token is less then the threshold, divide it
+  // otherwise just subtract the threshold to get in the safe zone
+  return tokenExpired < threshold
+    ? tokenExpired / 2
+    : tokenExpired - threshold
 }

--- a/src/internal/utils/token.ts
+++ b/src/internal/utils/token.ts
@@ -1,0 +1,21 @@
+import jwt_decode from "jwt-decode";
+
+export function untilTokenExpired(accessToken: string): number {
+  try {
+    const { exp: expired } = jwt_decode<{ exp: number }>(accessToken);
+    const now = Date.now() / 1000;
+
+    // if expired, return 0 so it can call the refresh directly
+    if(expired < now ) {
+      return 0;
+    }
+
+    // calculate the diff
+    const diff = expired - now;
+
+    // return the ms
+    return diff * 1000;
+  } catch (e) {
+    return 0;
+  }
+}


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Refreshing a token was based on a fixed amount of `ms` and it was set to interval. This brings a couple odd situations.
1. When a token expired and got refreshed 3 times, it also set 3 intervals. What result in 9 refreshes in the end.
2. When you visit the page after a period of time (before the expiration). The delay never hits the expiration.

Issue Number: N/A

## What is the new behavior?
The tokenmanager set the new delay based on the `exp` of the token. Also it will set a timeout instead of an interval.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

