### PR TITLE
fix(token): restart timeout after digest ends

### DIFF
--- a/src/api/core/tokenManager.spec.ts
+++ b/src/api/core/tokenManager.spec.ts
@@ -318,13 +318,13 @@ describe("TokenManager", () => {
         access_token: faker.random.word(),
         refresh_token: faker.random.word(),
       });
-      const [ firstTimeout, secondTimeout ] = (subject as any).refreshes;
+      const [ firstTimeout, secondTimeout ] = Array.from((subject as any).refreshes.values());
       await subject.terminate();
       // @ts-ignore
       expect(global.clearTimeout).toHaveBeenNthCalledWith(1, firstTimeout);
       // @ts-ignore
       expect(global.clearTimeout).toHaveBeenNthCalledWith(2, secondTimeout);
-      expect((subject as any).refreshes).toEqual([]);
+      expect((subject as any).refreshes.size).toBe(0);
       clearTimeoutSpy.mockRestore();
     });
 


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `timeout` was not set again after the previous one ends.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
A new timeout is set when the previous has been ended.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

