### PR TITLE
feat(token): refresh token before a request made if digest fails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8961,6 +8961,11 @@
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
       "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
     },
+    "jwt-simple": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/jwt-simple/-/jwt-simple-0.5.6.tgz",
+      "integrity": "sha512-40aUybvhH9t2h71ncA1/1SbtTNCVZHgsTsTgqPUxGWDmUDrXyDf2wMNQKEbdBjbf4AI+fQhbECNTV6lWxQKUzg=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "form-data": "^2.3.3",
     "injection-js": "^2.3.0",
     "jwt-decode": "^3.1.2",
+    "jwt-simple": "^0.5.6",
     "node-fetch": "^2.6.0",
     "reflect-metadata": "^0.1.12",
     "rxjs": "^6.5.5",

--- a/spec/testUtils.ts
+++ b/spec/testUtils.ts
@@ -200,6 +200,8 @@ export const mockRequestError = ({
   id, request, httpStatus: { code, status }, message,
 });
 
+export const randomNumber = (min: number, max: number): number => Math.floor(Math.random() * (max - min + 1) ) + min
+
 export * from "./requestMethod";
 export * from "./resource";
 export * from "./queryActionType";

--- a/spec/token.ts
+++ b/spec/token.ts
@@ -1,0 +1,18 @@
+import { encode } from "jwt-simple";
+import { randomNumber } from "./testUtils";
+
+export function createTestToken(expired = false): string {
+  const year = expired? new Date().getFullYear() - 1 : new Date().getFullYear() + 1
+  const month = (randomNumber(1, 12));
+  const day = (randomNumber(1, 25));
+  const hour = (randomNumber(1, 12));
+  const minutes = (randomNumber(1, 59));
+
+  return encode({
+    iss: "Jexia.com",
+    iat: new Date(new Date().getFullYear(), month, day, hour, minutes).getTime() / 1000,
+    exp: new Date(year, month, day, hour, minutes).getTime() / 1000,
+    aud: "jexia.com",
+    sub: "support@jexia.com",
+  }, "secretJexia");
+}

--- a/src/api/core/componentStorage.spec.ts
+++ b/src/api/core/componentStorage.spec.ts
@@ -6,6 +6,7 @@ import {
   WebStorageComponent,
 } from "./componentStorage";
 import { Tokens } from "./tokenManager";
+import { createTestToken } from "../../../spec/token";
 
 class WebStorageApiMock {
   private dictionary: any = {};
@@ -24,7 +25,7 @@ class WebStorageApiMock {
 }
 const generateTokens = (): Tokens => ({
   refresh_token: faker.random.uuid(),
-  access_token: faker.random.uuid(),
+  access_token: createTestToken(),
 });
 
 describe("ComponentStorage", ()  => {
@@ -78,6 +79,14 @@ describe("ComponentStorage", ()  => {
       it("should clear the saved tokens", () => {
         instanceComponent.clear();
         expect(instanceComponent.isEmpty()).toBeTruthy();
+      });
+
+      it("should get the aliases from the tokens", () => {
+        const tokens = generateTokens();
+        instanceComponent.setTokens("defaultTokens", tokens, true);
+
+        const aliases = instanceComponent.getTokenAliases(tokens.access_token);
+        expect(aliases).toEqual(["defaultTokens"]);
       });
     });
   });

--- a/src/api/core/componentStorage.ts
+++ b/src/api/core/componentStorage.ts
@@ -2,6 +2,19 @@
 import { Tokens } from "./tokenManager";
 
 /**
+ * fetch an arrau of all aliases for one access token
+ * @internal
+ */
+export const getAliases = (accessToken: string, tokens: tokenList): string[] => Object.entries(tokens)
+  .filter(([, token]) => token.access_token === accessToken)
+  .map(([alias]) => alias);
+
+/**
+ * @internal
+ */
+export type tokenList = {[auth: string]: Tokens}
+
+/**
  * @internal
  */
 export interface IStorageComponent {
@@ -32,6 +45,11 @@ export interface IStorageComponent {
    * Remove
    */
   clear(): void;
+
+  /**
+   * Get all aliases per accessToken
+   */
+  getTokenAliases(accessToken: string): string[];
 }
 
 /**
@@ -44,7 +62,7 @@ export class WebStorageComponent implements IStorageComponent {
   private storage: Storage;
 
   /* get all tokens from the storage */
-  private get tokens(): {[auth: string]: Tokens} {
+  private get tokens(): tokenList {
     let tokens;
     try {
       tokens = JSON.parse(this.storage.getItem(this.storageKey) as string);
@@ -85,6 +103,10 @@ export class WebStorageComponent implements IStorageComponent {
   public clear(): void {
     this.storage.removeItem(this.storageKey);
   }
+
+  public getTokenAliases(accessToken: string): string[] {
+    return getAliases(accessToken, this.tokens)
+  }
 }
 
 /**
@@ -92,7 +114,7 @@ export class WebStorageComponent implements IStorageComponent {
  */
 export class MemoryStorageComponent implements IStorageComponent {
 
-  private tokens: { [auth: string]: Tokens } = {};
+  private tokens: tokenList = {};
 
   private defaultTokens: string;
 
@@ -118,6 +140,10 @@ export class MemoryStorageComponent implements IStorageComponent {
 
   public clear(): void {
     this.tokens = {};
+  }
+
+  public getTokenAliases(accessToken: string): string[] {
+    return getAliases(accessToken, this.tokens)
   }
 }
 

--- a/src/api/core/tokenManager.spec.ts
+++ b/src/api/core/tokenManager.spec.ts
@@ -318,13 +318,13 @@ describe("TokenManager", () => {
         access_token: faker.random.word(),
         refresh_token: faker.random.word(),
       });
-      const [ firstTimeout, secondTimeout ] = (subject as any).refreshes;
+      const [ firstTimeout, secondTimeout ] = Array.from((subject as any).refreshes.values());
       await subject.terminate();
       // @ts-ignore
       expect(global.clearTimeout).toHaveBeenNthCalledWith(1, firstTimeout);
       // @ts-ignore
       expect(global.clearTimeout).toHaveBeenNthCalledWith(2, secondTimeout);
-      expect((subject as any).refreshes).toEqual([]);
+      expect((subject as any).refreshes.size).toBe(0);
       clearTimeoutSpy.mockRestore();
     });
 

--- a/src/api/core/tokenManager.ts
+++ b/src/api/core/tokenManager.ts
@@ -226,10 +226,10 @@ export class TokenManager {
           ({ access_token }: Tokens) => this.startRefreshDigest(aliases, access_token), // start a digest for the new token
           () => this.terminate(), // TODO: send an event out, so the user can act on that,
         );
-    }, delay)
+    }, delay);
 
     // save the timeout ref, and ref it to the accessToken key
-    this.refreshes.set(accessToken, timer)
+    this.refreshes.set(accessToken, timer);
   }
 
   /**
@@ -240,7 +240,7 @@ export class TokenManager {
     if(this.refreshes.has(currentAccessToken)) {
       const timer = this.refreshes.get(currentAccessToken);
 
-      clearTimeout(timer)
+      clearTimeout(timer);
       this.refreshes.delete(currentAccessToken);
     }
   }

--- a/src/api/core/tokenManager.ts
+++ b/src/api/core/tokenManager.ts
@@ -1,9 +1,9 @@
 import { Injectable, InjectionToken } from "injection-js";
-import { from, Observable } from "rxjs";
-import { catchError, map, tap } from "rxjs/operators";
+import { from, Observable, iif, of } from "rxjs";
+import {catchError, map, tap, switchMap, finalize} from "rxjs/operators";
 import { API, MESSAGE, getApiUrl, getProjectId } from "../../config";
 import { IRequestError, RequestAdapter, RequestMethod } from "../../internal/requestAdapter";
-import { delayTokenRefresh } from "../../internal/utils";
+import { delayTokenRefresh, isTokenExpired } from "../../internal/utils";
 import { Logger } from "../logger/logger";
 import { TokenStorage } from "./componentStorage";
 
@@ -109,9 +109,22 @@ export class TokenManager {
 
   /**
    * Get access token for the specific authentication alias (APK by default)
+   * When a token is expired, try to refresh the token
    * @param {string} auth Authentication alias
    */
   public token(auth?: string): Observable<string> {
+    // refreshing a token means: cancel current digest for expired token, fetch new token, start new digest with new token
+    // due the digest, we are sure that it will not come to this, but to be 100% sure, its required deal with this
+    const $refresh = (accessToken: string): Observable<string> => {
+      const aliases: string[] = this.storage.getTokenAliases(accessToken);
+      return of(accessToken).pipe(
+        tap(currentAccessToken => this.removeRefreshDigest(currentAccessToken)),
+        switchMap(() => this.refresh(aliases)),
+        map(({ access_token }: Tokens): string => access_token),
+        tap(newAccessToken => this.startRefreshDigest(aliases, newAccessToken)),
+      )
+    };
+
     return from(this.resolved).pipe(
       map(() => {
         const tokens = this.storage.getTokens(auth);
@@ -120,6 +133,10 @@ export class TokenManager {
         }
         return tokens.access_token;
       }),
+      // check if the token is expired, if so, refresh the token and assign it to the storage
+      switchMap((accessToken: string) => iif(
+        () => isTokenExpired(accessToken), $refresh(accessToken), of(accessToken)),
+      ),
     );
   }
 
@@ -201,16 +218,31 @@ export class TokenManager {
     const delay = delayTokenRefresh(accessToken)
     const timer = setTimeout(() => {
       this.logger.debug("tokenManager", `refresh ${aliases[0]} token`);
-      this.refreshes.delete(accessToken);
       this.refresh(aliases)
+        .pipe(
+          finalize(() => this.removeRefreshDigest(accessToken)),
+        )
         .subscribe(
           ({ access_token }: Tokens) => this.startRefreshDigest(aliases, access_token), // start a digest for the new token
-          () => this.terminate() // TODO: send an event out, so the user can act on that
+          () => this.terminate(), // TODO: send an event out, so the user can act on that,
         );
     }, delay)
 
     // save the timeout ref, and ref it to the accessToken key
     this.refreshes.set(accessToken, timer)
+  }
+
+  /**
+   * Stop a refreshing digest
+   * @ignore
+   */
+  private removeRefreshDigest(currentAccessToken: string): void {
+    if(this.refreshes.has(currentAccessToken)) {
+      const timer = this.refreshes.get(currentAccessToken);
+
+      clearTimeout(timer)
+      this.refreshes.delete(currentAccessToken);
+    }
   }
 
   /**

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,7 +2,7 @@ import { IAuthOptions } from "../api/core/tokenManager";
 
 export const API = {
   AUTH: "auth",
-  REFRESH: "refresh",
+  REFRESH: "auth/refresh",
   DATA: {
     ENDPOINT: "ds",
   },

--- a/src/internal/utils/token.spec.ts
+++ b/src/internal/utils/token.spec.ts
@@ -1,9 +1,9 @@
-import { untilTokenExpired, delayTokenRefresh } from "./token";
+import * as faker from "faker"
+import { untilTokenExpired, delayTokenRefresh, isTokenExpired } from "./token";
+import { createTestToken } from "../../../spec/token";
 
-// Set to the year 2000
-const expiredToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXN0IFRva2VuIiwiaWF0Ijo5NzYyODUzMDQsImV4cCI6OTc2Mjg1MzA0LCJhdWQiOiJ3d3cuamV4aWEuY29tIiwic3ViIjoiam9obkBkb2UuY29tIn0.RkxTdiuiIvwvOIVBVqMJt6hpiobz7_FG0aKyE686eE0";
-// Set to the year 4000
-const futureToken = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJUZXN0IFRva2VuIiwiaWF0Ijo2NDA5MDE4OTMwNCwiZXhwIjo2NDA5MDE4OTMwNCwiYXVkIjoid3d3LmpleGlhLmNvbSIsInN1YiI6ImpvaG5AZG9lLmNvbSJ9.qXp8xLcaA0RrnVg097K49p6FGax5HQAQ8NcutpKpA0w";
+const expiredToken = createTestToken(true);
+const futureToken = createTestToken();
 
 describe("Token utils", () => {
   describe("getting time until token expired", () => {
@@ -27,6 +27,23 @@ describe("Token utils", () => {
     it("should return time until the token got expired", () => {
       const time = delayTokenRefresh(futureToken);
       expect(time).toBeGreaterThan(0);
+    });
+  });
+
+  describe.only("token expired", () => {
+    it("should return 'false' when the token got expired", () => {
+      const expired = isTokenExpired(expiredToken)
+      expect(expired).toBe(true);
+    });
+
+    it("should return 'true' when the token got expired", () => {
+      const expired = isTokenExpired(futureToken);
+      expect(expired).toBe(false);
+    });
+
+    it("should return 'true' when dealing with an invalid token", () => {
+      const expired = isTokenExpired(faker.random.word());
+      expect(expired).toBe(true);
     });
   });
 });

--- a/src/internal/utils/token.ts
+++ b/src/internal/utils/token.ts
@@ -38,3 +38,17 @@ export function delayTokenRefresh(accessToken: string): number {
     ? tokenExpired / 2
     : tokenExpired - threshold
 }
+
+/**
+ * Check if a token is expired or not
+ * @internal
+ */
+export function isTokenExpired(token: string): boolean {
+  try {
+    const { exp: expired } = jwt_decode<{ exp: number }>(token);
+    const now = Date.now() / 1000; // exp is represented in seconds since epoch
+    return now > expired;
+  } catch (e) {
+    return true;
+  }
+}


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently we have a digest in place (`setTimeout`) that will execute when the token expired to fetch a new one.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
To be **100%** sure that we have a valid token, we do a simple check before a request is made. If the token got expired, fetch a new token just before the actual request can be made and use that one instead.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
