### PR TITLE
feat(ums): getUser can fallback on the default alias if set

### DIFF
--- a/src/api/core/componentStorage.ts
+++ b/src/api/core/componentStorage.ts
@@ -11,6 +11,13 @@ export const getAliases = (accessToken: string, tokens: tokenList): string[] => 
   .map(([alias]) => alias);
 
 /**
+ * fetch an array of all aliases currently used
+ * @internal
+ */
+export const getAllAliases = (tokens: tokenList): string[] => Object.entries(tokens)
+  .map(([alias]) => alias);
+
+/**
  * @internal
  */
 export type tokenList = {[auth: string]: Tokens};
@@ -63,6 +70,11 @@ export interface IStorageComponent {
    * Get all aliases per accessToken
    */
   getTokenAliases(accessToken: string): string[];
+
+  /**
+   * Get all aliases per accessToken
+   */
+  getAllTokenAliases(): string[];
 }
 
 /**
@@ -142,6 +154,10 @@ export class WebStorageComponent implements IStorageComponent {
   public getTokenAliases(accessToken: string): string[] {
     return getAliases(accessToken, this.tokens);
   }
+
+  public getAllTokenAliases(): string[] {
+    return getAllAliases(this.tokens);
+  }
 }
 
 /**
@@ -193,6 +209,10 @@ export class MemoryStorageComponent implements IStorageComponent {
 
   public getTokenAliases(accessToken: string): string[] {
     return getAliases(accessToken, this.tokens);
+  }
+
+  public getAllTokenAliases(): string[] {
+    return getAllAliases(this.tokens);
   }
 }
 

--- a/src/api/core/tokenManager.spec.ts
+++ b/src/api/core/tokenManager.spec.ts
@@ -334,7 +334,7 @@ describe("TokenManager", () => {
       subject.token().subscribe(
         () => done("successfully received the token"),
         (error) => {
-          expect(error.message).toEqual(MESSAGE.TokenManager.TOKEN_NOT_AVAILABLE);
+          expect(error.message).toEqual(MESSAGE.TOKEN_MANAGER.TOKEN_NOT_AVAILABLE);
           done();
         },
       );
@@ -347,7 +347,7 @@ describe("TokenManager", () => {
       subject.token("randomToken").subscribe(
         () => done("successfully received the token"),
         (error) => {
-          expect(error.message).toEqual(MESSAGE.TokenManager.TOKEN_NOT_AVAILABLE);
+          expect(error.message).toEqual(MESSAGE.TOKEN_MANAGER.TOKEN_NOT_AVAILABLE);
           done();
         },
       );
@@ -414,7 +414,7 @@ describe("TokenManager", () => {
       subject.token().subscribe(
         () => done("successfully received the token"),
         (error) => {
-          expect(error.message).toEqual(MESSAGE.TokenManager.TOKEN_NOT_AVAILABLE);
+          expect(error.message).toEqual(MESSAGE.TOKEN_MANAGER.TOKEN_NOT_AVAILABLE);
           done();
         },
       );
@@ -501,6 +501,14 @@ describe("TokenManager", () => {
       expect(subject.validateTokenAlias()).toBe(false);
     });
 
+    it("should return FALSE when the given alias has never been set", () => {
+      const { subject } = createSubject();
+
+      jest.spyOn((subject as any).storage, "getAllTokenAliases").mockReturnValue([faker.random.word()]);
+
+      expect(subject.validateTokenAlias(faker.random.word())).toBe(false);
+    });
+
     it("should return the DEFAULT alias if no alias is given and is not the SYSTEM DEFAULT", () => {
       const { subject } = createSubject();
       const defaultAlias = faker.random.word();
@@ -513,6 +521,8 @@ describe("TokenManager", () => {
     it("should return the given alias if all conditions are met", () => {
       const { subject } = createSubject();
       const alias = faker.random.word();
+
+      jest.spyOn((subject as any).storage, "getAllTokenAliases").mockReturnValue([alias]);
 
       expect(subject.validateTokenAlias(alias)).toBe(alias);
     });

--- a/src/api/core/tokenManager.ts
+++ b/src/api/core/tokenManager.ts
@@ -131,7 +131,7 @@ export class TokenManager {
       map(() => {
         const tokens = this.storage.getTokens(auth);
         if (!tokens) {
-          throw new Error(MESSAGE.TokenManager.TOKEN_NOT_AVAILABLE);
+          throw new Error(MESSAGE.TOKEN_MANAGER.TOKEN_NOT_AVAILABLE);
         }
         return tokens.access_token;
       }),
@@ -350,6 +350,11 @@ export class TokenManager {
   public validateTokenAlias(alias?: string): boolean | string {
     // bail out if the alias is not set and the default is set to the SYSTEM DEFAULT
     if (!alias && this.defaultAuthAlias === APIKEY_DEFAULT_ALIAS) {
+      return false;
+    }
+
+    // bail out if the alias has never been used
+    if (alias && !this.storage.getAllTokenAliases().includes(alias)) {
       return false;
     }
 

--- a/src/api/ums/umsModule.spec.ts
+++ b/src/api/ums/umsModule.spec.ts
@@ -3,7 +3,7 @@ import * as faker from "faker";
 import { ReflectiveInjector } from "injection-js";
 import { of } from "rxjs";
 import { createMockFor, SpyObj } from "../../../spec/testUtils";
-import { API, getApiUrl } from "../../config";
+import { API, getApiUrl, MESSAGE } from "../../config";
 import { RequestExecuter } from "../../internal/executer";
 import { RequestAdapter, RequestMethod } from "../../internal/requestAdapter";
 import { deferPromise, parseQueryParams, toQueryParams } from "../../internal/utils";
@@ -401,9 +401,18 @@ describe("UMS Module", () => {
   describe("user management", () => {
 
     describe("get current user", () => {
+      it("should return error if alias does not exists", async () => {
+        const { subject, signInOptions, tokenManagerMock, systemDefer, init } = createSubject();
+        jest.spyOn(tokenManagerMock, "token");
+        systemDefer.resolve();
+        await init();
+        expect(() => subject.getUser(signInOptions.alias)).toThrow(MESSAGE.TOKEN_MANAGER.ALIAS_NOT_FOUND);
+      });
+
       it("should get token from token manager by provided alias", async () => {
         const { subject, signInOptions, tokenManagerMock, systemDefer, init } = createSubject();
         jest.spyOn(tokenManagerMock, "token");
+        jest.spyOn((tokenManagerMock as any), "validateTokenAlias").mockReturnValue(signInOptions.alias);
         systemDefer.resolve();
         await init();
         await subject.getUser(signInOptions.alias);
@@ -411,7 +420,8 @@ describe("UMS Module", () => {
       });
 
       it("should call correct API to get current user", async () => {
-        const { subject, access_token, signInOptions, requestAdapterMock, systemDefer, init } = createSubject();
+        const { subject, access_token, signInOptions, requestAdapterMock, systemDefer, init, tokenManagerMock } = createSubject();
+        jest.spyOn((tokenManagerMock as any), "validateTokenAlias").mockReturnValue(signInOptions.alias);
         systemDefer.resolve();
         await init();
         await subject.getUser(signInOptions.alias).subscribe();

--- a/src/api/ums/umsModule.ts
+++ b/src/api/ums/umsModule.ts
@@ -1,7 +1,7 @@
 import { ReflectiveInjector } from "injection-js";
 import { Observable } from "rxjs";
 import { map, switchMap, pluck, tap } from "rxjs/operators";
-import { API, getApiUrl } from "../../config";
+import { API, getApiUrl, MESSAGE } from "../../config";
 import { RequestExecuter } from "../../internal/executer";
 import { RequestAdapter, RequestMethod } from "../../internal/requestAdapter";
 import { toQueryParams, parseQueryParams } from "../../internal/utils";
@@ -140,8 +140,14 @@ export class UMSModule<
    * Fetch currently authorized user
    * @param alias {string} Authorization alias
    */
-  public getUser(alias: string): Observable<D> {
-    return this.tokenManager.token(alias).pipe(
+  public getUser(alias?: string): Observable<D> {
+    const validatedAlias = this.tokenManager.validateTokenAlias(alias);
+
+    if (!validatedAlias) {
+      throw new Error(MESSAGE.TOKEN_MANAGER.ALIAS_NOT_FOUND);
+    }
+
+    return this.tokenManager.token(validatedAlias as string).pipe(
       switchMap((token: string) => this.requestAdapter.execute<D>(
         this.getUrl(API.UMS.USER),
         { headers: { Authorization: `Bearer ${token}` }},

--- a/src/config/message.ts
+++ b/src/config/message.ts
@@ -18,8 +18,9 @@ export const MESSAGE = {
     NOT_OPEN_MESSAGE: "The connection seems to be closed. Did you properly initialize the RTC Module by calling the init method? Or maybe you terminated the RTC Module early?",
     NO_WESBSOCKET_PRESENT: "The RTC Module seems to be missing a valid websocket object. Did you properly initialize the RTC Module by calling the init method?",
   },
-  TokenManager: {
+  TOKEN_MANAGER: {
     TOKEN_NOT_AVAILABLE: "You need to log in before you can access the token.",
+    ALIAS_NOT_FOUND: "No tokens found for this alias or DEFAULT alias.",
   },
   FILESET: {
     UPLOADING_FILE_ERROR: "Couldn't upload a file: ",


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?


<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, `ums.getUser()` cannot be fallback on the alias that has been set as the DEFAULT.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
For `ums.getUser()` you can now omit the `alias` param so it can fallback on the alias that set as DEFAULT.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
