### PR TITLE
refactor(filter): rename satisfiesRegexp to satisfiesRegex

### DIFF
--- a/src/api/core/filteringApi.spec.ts
+++ b/src/api/core/filteringApi.spec.ts
@@ -158,7 +158,7 @@ describe("FieldFilter class", () => {
       testParams({
         value,
         operator: "regex",
-        getCriterion: (subject) => subject.satisfiesRegexp(value),
+        getCriterion: (subject) => subject.satisfiesRegex(value),
       });
     });
 

--- a/src/api/core/filteringApi.ts
+++ b/src/api/core/filteringApi.ts
@@ -52,8 +52,8 @@ export class FieldFilter<U> {
     return new FilteringCriterion(new FilteringCondition(this.fieldName, "like", value));
   }
 
-  public satisfiesRegexp(regexp: string): IFilteringCriterion {
-    return new FilteringCriterion(new FilteringCondition(this.fieldName, "regex", regexp));
+  public satisfiesRegex(regex: string): IFilteringCriterion {
+    return new FilteringCriterion(new FilteringCondition(this.fieldName, "regex", regex));
   }
 
   public isBetween(start: U, end: U): IFilteringCriterion {


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The docs talk about `satisfiesRegex` but in the code it is `satisfiesRegexp`

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
We unify it to just `satisfiesRegex`

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Instead of using `satisfiesRegexp` you should use `satisfiesRegex`

```
.where(field => field("title").satisfiesRegex('a-z0-9'))
```
