### PR TITLE
fix(rtc): when using the ums

### DIFF
--- a/src/api/core/client.ts
+++ b/src/api/core/client.ts
@@ -4,6 +4,7 @@ import { deferPromise } from "../../internal/utils";
 import { Logger } from "../logger/logger";
 import { IModule, ModuleConfiguration } from "./module";
 import { AuthOptions, IAuthOptions, TokenManager } from "./tokenManager";
+import { Dispatcher } from "./dispatcher";
 
 /**
  * @internal
@@ -80,6 +81,7 @@ export class Client {
       },
       Logger,
       TokenManager,
+      Dispatcher,
     ]);
     this.tokenManager = injector.get(TokenManager);
 

--- a/src/api/core/dispatcher.spec.ts
+++ b/src/api/core/dispatcher.spec.ts
@@ -1,0 +1,75 @@
+// tslint:disable:no-string-literal
+import * as faker from "faker";
+import { Dispatcher } from "./dispatcher";
+
+describe("Dispatcher", () => {
+  function createSubject({
+    event = faker.random.word(),
+    alias = faker.random.word(),
+    // tslint:disable-next-line:no-empty
+    listener = () => {},
+    subscribe = true,
+  } = {}) {
+    const subject = new Dispatcher();
+
+    if (subscribe) {
+      // tslint:disable-next-line:no-empty
+      subject.on(event, alias, listener);
+    }
+
+    return {
+      subject,
+      event,
+      alias,
+      listener,
+    };
+  }
+
+  describe("Subscribe", () => {
+    it("should subscribe to an event", () => {
+      const { subject, event } = createSubject();
+
+      expect((subject as any).events.get(event).size).toBe(1);
+    });
+  });
+
+  describe("Unsubscribe", () => {
+    it("should unsubscribe from an event", () => {
+      const { subject, event, alias } = createSubject();
+
+      subject.off(event, alias);
+
+      expect((subject as any).events.get(event).size).toBe(0);
+    });
+
+    it("should do nothing when an invalid event is given", () => {
+      const { subject, alias, event } = createSubject();
+      const invalidEvent = faker.random.word();
+
+      subject.off(invalidEvent, alias);
+
+      expect((subject as any).events.get(event).size).toBe(1);
+    });
+  });
+
+  describe("Emit", () => {
+    it("should emit listener", () => {
+      const listener = jest.fn();
+      const { subject, event, alias } = createSubject({ listener });
+
+      subject.emit(event, alias);
+
+      expect(listener).toHaveBeenCalled();
+    });
+
+    it("should NOT emit when an invalid event is given", () => {
+      const listener = jest.fn();
+      const { subject } = createSubject({ listener });
+      const event = faker.random.word();
+
+      subject.emit(event);
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/api/core/dispatcher.ts
+++ b/src/api/core/dispatcher.ts
@@ -1,0 +1,57 @@
+import { Injectable } from "injection-js";
+
+type FunctionEvents = () => void;
+
+@Injectable()
+export class Dispatcher {
+  private events = new Map<string, Map<string, FunctionEvents>>();
+
+  /**
+   * Subscribe to an event
+   *
+   * @param {string} eventName the name of the event to listen
+   * @param {string} key The name/key to assign the listener
+   * @param {FunctionEvents} listener The listener that will execute when called
+   */
+  public on(eventName: string, key: string, listener: FunctionEvents) {
+    const listeners = this.events.get(eventName) || new Map<string, FunctionEvents>();
+
+    listeners.set(key, listener);
+
+    this.events.set(eventName, listeners);
+  }
+
+  /**
+   * Unsubscribe from an event
+   *
+   * @param {string} eventName the name of the event to listen
+   * @param {string} key The name/key to assign the listener
+   */
+  public off(eventName: string, key: string) {
+    const listeners = this.events.get(eventName);
+
+    if (!listeners) {
+      return;
+    }
+
+    listeners.delete(key);
+
+    this.events.set(eventName, listeners);
+  }
+
+  /**
+   * Emit an event
+   *
+   * @param {string} eventName the name of the event to call
+   * @param {any} data The extra data that will be send to the listener
+   */
+  public emit(eventName: string, ...data: any) {
+    const listeners = this.events.get(eventName);
+
+    if (!listeners) {
+      return;
+    }
+
+    listeners.forEach(callback => callback.apply(data));
+  }
+}

--- a/src/api/realtime/realTimeModule.spec.ts
+++ b/src/api/realtime/realTimeModule.spec.ts
@@ -5,12 +5,20 @@ import { createMockFor, SpyObj, validClientOpts } from "../../../spec/testUtils"
 import { RequestExecuter } from "../../../src/internal/executer";
 import { MESSAGE, getRtcUrl } from "../../config";
 import { AuthOptions, TokenManager } from "../core/tokenManager";
+import { Dispatcher } from "../core/dispatcher";
 import { IWebSocket, WebSocketState } from "./realTime.interfaces";
 import { RealTimeModule } from "./realTimeModule";
 
 describe("Real Time Module", () => {
 
   const shouldHaveFailed = "Should have failed!";
+  const dispatcherEvents =  [
+    "tokenLogin",
+    "tokenRefresh",
+    "umsLogin",
+    "umsSwitchUser",
+    "umsLogout",
+  ];
 
   function createSubject({
     webSocketMock = createMockFor(["send", "close"]) as SpyObj<IWebSocket>,
@@ -19,11 +27,13 @@ describe("Real Time Module", () => {
     tokenManagerReturnValue = of(token),
     tokenManagerMock = createMockFor(TokenManager, {}, { token: () => tokenManagerReturnValue }),
     injectorMock = createMockFor(["get", "resolveAndCreateChild"]) as SpyObj<ReflectiveInjector>,
+    dispatcherMock = new Dispatcher(), // we need to call the emit function, so we pass the real class here
   } = {}) {
     const injectorMap = new Map<any, any>([
       [TokenManager, tokenManagerMock],
       [AuthOptions, validClientOpts],
       [RequestExecuter, createMockFor(RequestExecuter)],
+      [Dispatcher, dispatcherMock],
     ]);
     injectorMock.get.mockImplementation((key: any) => injectorMap.get(key));
     injectorMock.resolveAndCreateChild.mockImplementation(() => injectorMock);
@@ -35,39 +45,178 @@ describe("Real Time Module", () => {
       injectorMock,
       tokenManagerMock,
       subject,
-      moduleInit() {
-        const promise = subject.init(injectorMock);
+      async moduleConnect() {
+        await subject.init(injectorMock);
+        const promise = (subject as any).connect();
         tokenManagerMock.token().toPromise().then(() => webSocketMock.onopen && webSocketMock.onopen({}));
         return promise;
       },
+      dispatcherMock,
     };
   }
 
   describe("when initializing", () => {
+    it("should subscribe to the system events", async () => {
+      const { subject, injectorMock } = createSubject();
+
+      spyOn((subject as any), "listenToEvents");
+      await subject.init(injectorMock);
+
+      expect((subject as any).listenToEvents).toHaveBeenCalled();
+    });
+  });
+
+  describe("listen to system events", () => {
+    dispatcherEvents.forEach(event => {
+      it(`should subscribe to the event ${event}`, async () => {
+        const { subject, dispatcherMock, injectorMock } = createSubject();
+
+        spyOn(dispatcherMock, "on");
+        await subject.init(injectorMock); // events are subscribe inside the init function
+
+        expect(dispatcherMock.on).toHaveBeenCalledWith(event, "rtcConnect", expect.anything());
+      });
+    });
+
+    describe("receiving event: TokenLogin", () => {
+      it("should connect when there is no open connection", async () => {
+        const { subject, dispatcherMock, injectorMock } = createSubject();
+
+        spyOn((subject as any), "connect");
+        await subject.init(injectorMock);
+        dispatcherMock.emit("tokenLogin");
+
+        expect((subject as any).connect).toHaveBeenCalled();
+      });
+
+      it("should set the tokensGivenOnInit marker to TRUE", async () => {
+        const { subject, dispatcherMock, injectorMock } = createSubject();
+
+        await subject.init(injectorMock);
+        dispatcherMock.emit("tokenLogin");
+
+        expect((subject as any).tokensGivenOnInit).toBe(true);
+      });
+    });
+
+    describe("receiving event: tokenRefresh", () => {
+      it("should set the new token for the websocket", async () => {
+        const { subject, dispatcherMock, injectorMock, websocketBuilder } = createSubject();
+
+        spyOn((subject as any), "refreshToken");
+        await subject.init(injectorMock);
+        (subject as any).websocket = websocketBuilder;
+        dispatcherMock.emit("tokenRefresh");
+
+        expect((subject as any).refreshToken).toHaveBeenCalled();
+      });
+    });
+
+    describe("receiving event: umsLogin", () => {
+      it("should throw an error when using tokens via the jexiaClient().init()", async () => {
+        const { subject, dispatcherMock, injectorMock } = createSubject();
+
+        spyOn((subject as any), "throwUmsErrorIfNeeded");
+        await subject.init(injectorMock);
+        dispatcherMock.emit("umsLogin");
+
+        expect((subject as any).throwUmsErrorIfNeeded).toHaveBeenCalled();
+      });
+
+      it("should open a new connection when there is no connection open", async () => {
+        const { subject, dispatcherMock, injectorMock } = createSubject();
+
+        spyOn((subject as any), "connect");
+        await subject.init(injectorMock);
+        dispatcherMock.emit("umsLogin");
+
+        expect((subject as any).connect).toHaveBeenCalled();
+      });
+
+      it("should set a new token for the websocket if there is an open connection", async () => {
+        const { subject, dispatcherMock, injectorMock, websocketBuilder } = createSubject();
+
+        spyOn((subject as any), "refreshToken");
+        await subject.init(injectorMock);
+        (subject as any).websocket = websocketBuilder;
+        dispatcherMock.emit("umsLogin");
+
+        expect((subject as any).refreshToken).toHaveBeenCalled();
+      });
+    });
+
+    describe("receiving event: umsSwitchUser", () => {
+      it("should throw an error when using tokens via the jexiaClient().init()", async () => {
+        const { subject, dispatcherMock, injectorMock } = createSubject();
+
+        spyOn((subject as any), "throwUmsErrorIfNeeded");
+        await subject.init(injectorMock);
+        dispatcherMock.emit("umsSwitchUser");
+
+        expect((subject as any).throwUmsErrorIfNeeded).toHaveBeenCalled();
+      });
+
+      it("should set a new token for the websocket", async () => {
+        const { subject, dispatcherMock, injectorMock, websocketBuilder } = createSubject();
+
+        spyOn((subject as any), "refreshToken");
+        await subject.init(injectorMock);
+        (subject as any).websocket = websocketBuilder;
+        dispatcherMock.emit("umsSwitchUser");
+
+        expect((subject as any).refreshToken).toHaveBeenCalled();
+      });
+    });
+
+    describe("receiving event: umsLogout", () => {
+      it("should throw an error when using tokens via the jexiaClient().init()", async () => {
+        const { subject, dispatcherMock, injectorMock } = createSubject();
+
+        spyOn((subject as any), "throwUmsErrorIfNeeded");
+        await subject.init(injectorMock);
+        dispatcherMock.emit("umsLogout");
+
+        expect((subject as any).throwUmsErrorIfNeeded).toHaveBeenCalled();
+      });
+
+      it("should terminate the connection", async () => {
+        const { subject, dispatcherMock, injectorMock } = createSubject();
+
+        spyOn(subject, "terminate");
+        await subject.init(injectorMock);
+        dispatcherMock.emit("umsLogout");
+
+        expect((subject as any).terminate).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("when connecting", () => {
 
     it("should start the websocket connection with the correct app url", async () => {
-      const { websocketBuilder, moduleInit, token } = createSubject();
-      await moduleInit();
+      const { websocketBuilder, moduleConnect, token } = createSubject();
+      await moduleConnect();
+
       expect(websocketBuilder).toHaveBeenCalledWith(getRtcUrl(validClientOpts, token));
     });
 
     it("should start dataset watch functionality after initialized with correct parameters", async () => {
-      const { webSocketMock, moduleInit, tokenManagerMock } = createSubject();
+      const { webSocketMock, moduleConnect, tokenManagerMock } = createSubject();
       const websocket = require("./websocket");
       spyOn(websocket, "start");
-      await moduleInit();
+      await moduleConnect();
       expect(websocket.start).toHaveBeenCalledWith(webSocketMock, jasmine.any(Function));
       const token = (websocket.start as jasmine.Spy).calls.mostRecent().args[1]();
       expect(token).toStrictEqual(tokenManagerMock.token().toPromise());
     });
 
     it("should not start dataset watch functionality if not initialized", async () => {
-      const { moduleInit, websocketBuilder } = createSubject();
+      const { moduleConnect, websocketBuilder } = createSubject();
       const websocket = require("./websocket");
       spyOn(websocket, "start");
       websocketBuilder.and.callFake(() => { throw new Error("builderError"); });
       try {
-        await moduleInit();
+        await moduleConnect();
         throw new Error(shouldHaveFailed);
       } catch (error) {
         expect(error.message).not.toBe(shouldHaveFailed);
@@ -75,11 +224,11 @@ describe("Real Time Module", () => {
       }
     });
 
-    it("should reject the initializing promise when the websocket builder returns an falsy value", async () => {
-      const { websocketBuilder, moduleInit } = createSubject();
+    it("should reject the initializing promise when the websocket builder returns a falsy value", async () => {
+      const { websocketBuilder, moduleConnect } = createSubject();
       websocketBuilder.and.returnValue(undefined);
       try {
-        await moduleInit();
+        await moduleConnect();
         throw new Error(shouldHaveFailed);
       } catch (error) {
         expect(error.message).toBe(MESSAGE.RTC.BAD_WEBSOCKET_CREATION_CALLBACK);
@@ -88,10 +237,10 @@ describe("Real Time Module", () => {
 
     it("should reject the initializing promise when the websocket builder throws an error", async () => {
       const builderError = "builderErrorMessage";
-      const { websocketBuilder, moduleInit } = createSubject();
+      const { websocketBuilder, moduleConnect } = createSubject();
       websocketBuilder.and.callFake(() => { throw new Error(builderError); });
       try {
-        await moduleInit();
+        await moduleConnect();
         throw new Error(shouldHaveFailed);
       } catch (error) {
         expect(error.message).toContain(MESSAGE.RTC.ERROR_CREATING_WEBSOCKET);
@@ -106,6 +255,7 @@ describe("Real Time Module", () => {
       });
       try {
         await subject.init(injectorMock);
+        await (subject as any).connect();
         throw new Error(shouldHaveFailed);
       } catch (error) {
         expect(error).toBe(tokenError);
@@ -114,7 +264,8 @@ describe("Real Time Module", () => {
 
     it("should reject the initializing promise when the websocket has an error event", async () => {
       const { subject, webSocketMock, tokenManagerMock, injectorMock } = createSubject();
-      const initPromise = subject.init(injectorMock);
+      await subject.init(injectorMock);
+      const initPromise = (subject as any).connect();
       tokenManagerMock.token().toPromise().then(() => webSocketMock.onerror("webSocketError"));
       try {
         await initPromise;
@@ -134,18 +285,23 @@ describe("Real Time Module", () => {
   });
 
   describe("when terminating", () => {
+    it("should resolve the terminating promise immediately if the websocket object does not exists", async () => {
+      const { subject, webSocketMock } = createSubject();
+      await subject.terminate();
+      expect(webSocketMock.close).not.toHaveBeenCalled();
+    });
 
     it("should resolve the terminating promise immediately if the websocket is closed already", async () => {
-      const { subject, webSocketMock, moduleInit } = createSubject();
-      await moduleInit();
+      const { subject, webSocketMock, moduleConnect } = createSubject();
+      await moduleConnect();
       (webSocketMock as any).readyState = WebSocketState.CLOSED;
       await subject.terminate();
       expect(webSocketMock.close).not.toHaveBeenCalled();
     });
 
     it("should resolve the terminating promise only after the websocket close event", async () => {
-      const { subject, webSocketMock, moduleInit } = createSubject();
-      await moduleInit();
+      const { subject, webSocketMock, moduleConnect } = createSubject();
+      await moduleConnect();
       let oncloseEvent = false;
       setTimeout(() => {
         webSocketMock.onclose({});
@@ -158,8 +314,8 @@ describe("Real Time Module", () => {
     });
 
     it("should reject the terminating promise when the websocket has an error event", async () => {
-      const { subject, webSocketMock, moduleInit } = createSubject();
-      await moduleInit();
+      const { subject, webSocketMock, moduleConnect } = createSubject();
+      await moduleConnect();
       const webSocketError = "webSocketError";
       webSocketMock.close.mockImplementation(() => webSocketMock.onerror(webSocketError));
       try {
@@ -170,6 +326,31 @@ describe("Real Time Module", () => {
       }
     });
 
+    it("should unsubscribe from the Dispatcher events", async () => {
+      const { subject, webSocketMock, moduleConnect, dispatcherMock } = createSubject();
+
+      spyOn(dispatcherMock, "off");
+      await moduleConnect();
+      setTimeout(() => {
+        webSocketMock.onclose({});
+      }, 100);
+      await subject.terminate();
+      dispatcherEvents.forEach(
+        (event, key) => expect(dispatcherMock.off).toHaveBeenNthCalledWith(key + 1, event, "rtcConnect"),
+      );
+    });
+
+  });
+
+  it("should send a refreshToken / setToken on the websocket connection", () => {
+    const { subject, injectorMock } = createSubject();
+    const websocket = require("./websocket");
+
+    subject.init(injectorMock);
+    spyOn(websocket, "refreshToken");
+    (subject as any).refreshToken();
+
+    expect(websocket.refreshToken).toHaveBeenCalled();
   });
 
 });

--- a/src/api/realtime/websocket.ts
+++ b/src/api/realtime/websocket.ts
@@ -76,15 +76,23 @@ export function start(webSocket: IWebSocket, getToken: IGetToken) {
         }
         break;
       default:
-        // JWT Refresh
-        getToken().then((token) => realTimeCommand(webSocket, {
-          command: RealTimeCommandTypes.JwtRefresh,
-          arguments: { token },
-        }));
+        refreshToken(webSocket, getToken);
     }
   };
 
   wsReadyDefer.resolve();
+}
+
+/**
+ * Send a JWT refresh call
+ *
+ * @internal
+ */
+export function refreshToken(webSocket: IWebSocket, getToken: IGetToken): void {
+  getToken().then((token) => realTimeCommand(webSocket, {
+    command: RealTimeCommandTypes.JwtRefresh,
+    arguments: { token },
+  }));
 }
 
 /**

--- a/src/config/message.ts
+++ b/src/config/message.ts
@@ -17,6 +17,7 @@ export const MESSAGE = {
     NOT_OPEN_ERROR: "not opened",
     NOT_OPEN_MESSAGE: "The connection seems to be closed. Did you properly initialize the RTC Module by calling the init method? Or maybe you terminated the RTC Module early?",
     NO_WESBSOCKET_PRESENT: "The RTC Module seems to be missing a valid websocket object. Did you properly initialize the RTC Module by calling the init method?",
+    UMS_ERROR: "You did set the 'key' & 'secret' via jexiaClient().init() while you are using ums. In this case you can omit those keys.",
   },
   TOKEN_MANAGER: {
     TOKEN_NOT_AVAILABLE: "You need to log in before you can access the token.",

--- a/src/internal/utils/token.spec.ts
+++ b/src/internal/utils/token.spec.ts
@@ -30,7 +30,7 @@ describe("Token utils", () => {
     });
   });
 
-  describe.only("token expired", () => {
+  describe("token expired", () => {
     it("should return 'false' when the token got expired", () => {
       const expired = isTokenExpired(expiredToken);
       expect(expired).toBe(true);


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
The RTC will throw an error when using the UMS.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
RTC will listen to system events and act on that instead of open the connection directly.

- So when a user is logged in, it will open or set a new token for the current connection.
- When you switch a user it will set the token for that user to the current connection.
- It will close the connection when a user is logging out.
- it will set the new token after a token refresh
- it will open a connection when the KEY and SECRET are provided without using the UMS.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
