### PR TITLE
fix: close RTC connection only on ums.signOut

### DIFF
--- a/src/api/realtime/realTimeModule.spec.ts
+++ b/src/api/realtime/realTimeModule.spec.ts
@@ -222,11 +222,11 @@ describe("Real Time Module", () => {
       it("should terminate the connection", async () => {
         const { subject, dispatcherMock, injectorMock } = createSubject();
 
-        spyOn(subject, "terminate");
+        spyOn((subject as any), "closeConnection");
         await subject.init(injectorMock);
         dispatcherMock.emit("umsLogout");
 
-        expect((subject as any).terminate).toHaveBeenCalled();
+        expect((subject as any).closeConnection).toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
`ums.signOut()` should close the connection only instead terminate the whole RTC.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Just close the RTC connection

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
