### PR TITLE
feat(dispatcher): expose .on method to the client

### DIFF
--- a/src/api/core/client.ts
+++ b/src/api/core/client.ts
@@ -1,10 +1,10 @@
 import { InjectionToken, ReflectiveInjector } from "injection-js";
 import { Fetch, RequestAdapter } from "../../internal/requestAdapter";
-import { deferPromise } from "../../internal/utils";
+import { deferPromise, randomNumber } from "../../internal/utils";
 import { Logger } from "../logger/logger";
 import { IModule, ModuleConfiguration } from "./module";
 import { AuthOptions, IAuthOptions, TokenManager } from "./tokenManager";
-import { Dispatcher } from "./dispatcher";
+import { Dispatcher, DispatchEventsType, FunctionEvents } from "./dispatcher";
 
 /**
  * @internal
@@ -46,6 +46,7 @@ export class Client {
   private tokenManager: TokenManager;
   /* modules to be initialized */
   private modules: IModule[];
+  private dispatcher: Dispatcher;
 
   /**
    * @internal
@@ -84,6 +85,7 @@ export class Client {
       Dispatcher,
     ]);
     this.tokenManager = injector.get(TokenManager);
+    this.dispatcher = injector.get(Dispatcher);
 
     /* provide logger for the request adapter */
     injector.get(RequestAdapter).provideLogger(injector.get(Logger));
@@ -135,4 +137,16 @@ export class Client {
     return Object.assign({}, ...modules.map((module) => module.getConfig()));
   }
 
+  /**
+   * Expose the On event so the user can listen to events and act on that.
+   *
+   * @param eventName
+   * @param listener
+   */
+  public on(eventName: DispatchEventsType, listener: FunctionEvents) {
+    // use a random key, as the user will not unsubscribe from those events
+    const randomKey = `client:${randomNumber()}`;
+
+    this.dispatcher.on(eventName, randomKey , listener);
+  }
 }

--- a/src/api/core/dispatcher.spec.ts
+++ b/src/api/core/dispatcher.spec.ts
@@ -1,10 +1,12 @@
 // tslint:disable:no-string-literal
 import * as faker from "faker";
-import { Dispatcher } from "./dispatcher";
+import { Dispatcher, DispatchEvents, DispatchEventsType } from "./dispatcher";
+
+const randomEvent = () => faker.random.arrayElement(Object.values(DispatchEvents));
 
 describe("Dispatcher", () => {
   function createSubject({
-    event = faker.random.word(),
+    event = randomEvent(),
     alias = faker.random.word(),
     // tslint:disable-next-line:no-empty
     listener = () => {},
@@ -44,7 +46,7 @@ describe("Dispatcher", () => {
 
     it("should do nothing when an invalid event is given", () => {
       const { subject, alias, event } = createSubject();
-      const invalidEvent = faker.random.word();
+      const invalidEvent = faker.random.word() as DispatchEventsType;
 
       subject.off(invalidEvent, alias);
 
@@ -65,7 +67,7 @@ describe("Dispatcher", () => {
     it("should NOT emit when an invalid event is given", () => {
       const listener = jest.fn();
       const { subject } = createSubject({ listener });
-      const event = faker.random.word();
+      const event = faker.random.word() as DispatchEventsType;
 
       subject.emit(event);
 

--- a/src/api/core/dispatcher.ts
+++ b/src/api/core/dispatcher.ts
@@ -1,6 +1,17 @@
 import { Injectable } from "injection-js";
 
-type FunctionEvents = () => void;
+// TODO use enum (currently not possible as we extract the values for a new type as union)
+export const DispatchEvents = {
+  TOKEN_LOGIN: "token:login",
+  TOKEN_REFRESH: "token:refresh",
+  UMS_LOGIN: "ums:login",
+  UMS_SWITCH_USER: "ums:switchUser",
+  UMS_LOGOUT: "ums:logout",
+} as const;
+
+export type DispatchEventsType = typeof DispatchEvents[keyof typeof DispatchEvents];
+
+export type FunctionEvents = (...args: any[]) => void;
 
 @Injectable()
 export class Dispatcher {
@@ -13,8 +24,8 @@ export class Dispatcher {
    * @param {string} key The name/key to assign the listener
    * @param {FunctionEvents} listener The listener that will execute when called
    */
-  public on(eventName: string, key: string, listener: FunctionEvents) {
-    const listeners = this.events.get(eventName) || new Map<string, FunctionEvents>();
+  public on(eventName: DispatchEventsType, key: string, listener: FunctionEvents) {
+    const listeners = this.events.get(eventName) || new Map<DispatchEventsType, FunctionEvents>();
 
     listeners.set(key, listener);
 
@@ -27,7 +38,7 @@ export class Dispatcher {
    * @param {string} eventName the name of the event to listen
    * @param {string} key The name/key to assign the listener
    */
-  public off(eventName: string, key: string) {
+  public off(eventName: DispatchEventsType, key: string) {
     const listeners = this.events.get(eventName);
 
     if (!listeners) {
@@ -45,7 +56,7 @@ export class Dispatcher {
    * @param {string} eventName the name of the event to call
    * @param {any} data The extra data that will be send to the listener
    */
-  public emit(eventName: string, ...data: any) {
+  public emit(eventName: DispatchEventsType, ...data: any) {
     const listeners = this.events.get(eventName);
 
     if (!listeners) {

--- a/src/api/core/dispatcher.ts
+++ b/src/api/core/dispatcher.ts
@@ -4,6 +4,7 @@ import { Injectable } from "injection-js";
 export const DispatchEvents = {
   TOKEN_LOGIN: "token:login",
   TOKEN_REFRESH: "token:refresh",
+  TOKEN_REFRESH_FAILED: "token:refreshFailed",
   UMS_LOGIN: "ums:login",
   UMS_SWITCH_USER: "ums:switchUser",
   UMS_LOGOUT: "ums:logout",

--- a/src/api/core/tokenManager.spec.ts
+++ b/src/api/core/tokenManager.spec.ts
@@ -5,7 +5,7 @@ import { MESSAGE, getProjectId, APIKEY_DEFAULT_ALIAS } from "../../config";
 import { RequestAdapter, RequestMethod } from "../../internal/requestAdapter";
 import { Logger } from "../logger/logger";
 import { TokenManager, Tokens } from "./tokenManager";
-import { Dispatcher } from "./dispatcher";
+import { Dispatcher, DispatchEvents } from "./dispatcher";
 import { createTestToken } from "../../../spec/token";
 
 let terminate: () => void;
@@ -117,7 +117,7 @@ describe("TokenManager", () => {
     it("should dispatch an event", async () => {
       const { subject, dispatcherMock, validOptions } = createSubject();
       await subject.init(validOptions);
-      expect(dispatcherMock.emit).toHaveBeenCalledWith("tokenLogin");
+      expect(dispatcherMock.emit).toHaveBeenCalledWith(DispatchEvents.TOKEN_LOGIN);
     });
   });
 
@@ -477,7 +477,7 @@ describe("TokenManager", () => {
       const { subject, validOptions, dispatcherMock } = createSubject();
       await subject.init(validOptions);
       await (subject as any).refresh().toPromise();
-      expect(dispatcherMock.emit).toHaveBeenNthCalledWith(2, "tokenRefresh");
+      expect(dispatcherMock.emit).toHaveBeenNthCalledWith(2, DispatchEvents.TOKEN_REFRESH);
     });
 
     it("should reject promise if there is no token for specific auth", () => {

--- a/src/api/core/tokenManager.ts
+++ b/src/api/core/tokenManager.ts
@@ -6,7 +6,7 @@ import { IRequestError, RequestAdapter, RequestMethod } from "../../internal/req
 import { delayTokenRefresh, isTokenExpired } from "../../internal/utils";
 import { Logger } from "../logger/logger";
 import { TokenStorage } from "./componentStorage";
-import { Dispatcher } from "../core/dispatcher";
+import { Dispatcher, DispatchEvents } from "../core/dispatcher";
 
 /**
  * API interface of the authorization token
@@ -265,7 +265,7 @@ export class TokenManager {
   private login({auth = APIKEY_DEFAULT_ALIAS, key, secret}: IAuthOptions): Observable<Tokens> {
     return this.obtainTokens(auth, this.authUrl, { method: "apk", key, secret }).pipe(
       tap((tokens: Tokens) => this.addTokens([auth], tokens, true)),
-      tap(() => this.dispatcher.emit("tokenLogin")),
+      tap(() => this.dispatcher.emit(DispatchEvents.TOKEN_LOGIN)),
     );
   }
 
@@ -285,7 +285,7 @@ export class TokenManager {
       tap((refreshedTokens: Tokens) =>
         [auth, ...restAliases].forEach((alias) =>  this.storage.setTokens(alias, refreshedTokens)),
       ),
-      tap(() => this.dispatcher.emit("tokenRefresh")),
+      tap(() => this.dispatcher.emit(DispatchEvents.TOKEN_REFRESH)),
       catchError(() => {
         throw new Error("Refreshing token failed");
       }),

--- a/src/api/core/tokenManager.ts
+++ b/src/api/core/tokenManager.ts
@@ -287,6 +287,7 @@ export class TokenManager {
       ),
       tap(() => this.dispatcher.emit(DispatchEvents.TOKEN_REFRESH)),
       catchError(() => {
+        this.dispatcher.emit(DispatchEvents.TOKEN_REFRESH_FAILED);
         throw new Error("Refreshing token failed");
       }),
     );

--- a/src/api/realtime/realTimeModule.spec.ts
+++ b/src/api/realtime/realTimeModule.spec.ts
@@ -5,20 +5,13 @@ import { createMockFor, SpyObj, validClientOpts } from "../../../spec/testUtils"
 import { RequestExecuter } from "../../../src/internal/executer";
 import { MESSAGE, getRtcUrl } from "../../config";
 import { AuthOptions, TokenManager } from "../core/tokenManager";
-import { Dispatcher } from "../core/dispatcher";
+import { Dispatcher, DispatchEvents } from "../core/dispatcher";
 import { IWebSocket, WebSocketState } from "./realTime.interfaces";
 import { RealTimeModule } from "./realTimeModule";
 
 describe("Real Time Module", () => {
 
   const shouldHaveFailed = "Should have failed!";
-  const dispatcherEvents =  [
-    "tokenLogin",
-    "tokenRefresh",
-    "umsLogin",
-    "umsSwitchUser",
-    "umsLogout",
-  ];
 
   function createSubject({
     webSocketMock = createMockFor(["send", "close"]) as SpyObj<IWebSocket>,
@@ -107,7 +100,7 @@ describe("Real Time Module", () => {
   });
 
   describe("listen to system events", () => {
-    dispatcherEvents.forEach(event => {
+    Object.values(DispatchEvents).forEach(event => {
       it(`should subscribe to the event ${event}`, async () => {
         const { subject, dispatcherMock, injectorMock } = createSubject();
 
@@ -124,7 +117,7 @@ describe("Real Time Module", () => {
 
         spyOn((subject as any), "connect");
         await subject.init(injectorMock);
-        dispatcherMock.emit("tokenLogin");
+        dispatcherMock.emit(DispatchEvents.TOKEN_LOGIN);
 
         expect((subject as any).connect).toHaveBeenCalled();
       });
@@ -133,7 +126,7 @@ describe("Real Time Module", () => {
         const { subject, dispatcherMock, injectorMock } = createSubject();
 
         await subject.init(injectorMock);
-        dispatcherMock.emit("tokenLogin");
+        dispatcherMock.emit(DispatchEvents.TOKEN_LOGIN);
 
         expect((subject as any).tokensGivenOnInit).toBe(true);
       });
@@ -146,7 +139,7 @@ describe("Real Time Module", () => {
         spyOn((subject as any), "refreshToken");
         await subject.init(injectorMock);
         (subject as any).websocket = websocketBuilder;
-        dispatcherMock.emit("tokenRefresh");
+        dispatcherMock.emit(DispatchEvents.TOKEN_REFRESH);
 
         expect((subject as any).refreshToken).toHaveBeenCalled();
       });
@@ -158,7 +151,7 @@ describe("Real Time Module", () => {
 
         spyOn((subject as any), "throwUmsErrorIfNeeded");
         await subject.init(injectorMock);
-        dispatcherMock.emit("umsLogin");
+        dispatcherMock.emit(DispatchEvents.UMS_LOGIN);
 
         expect((subject as any).throwUmsErrorIfNeeded).toHaveBeenCalled();
       });
@@ -168,7 +161,7 @@ describe("Real Time Module", () => {
 
         spyOn((subject as any), "connect");
         await subject.init(injectorMock);
-        dispatcherMock.emit("umsLogin");
+        dispatcherMock.emit(DispatchEvents.UMS_LOGIN);
 
         expect((subject as any).connect).toHaveBeenCalled();
       });
@@ -179,7 +172,7 @@ describe("Real Time Module", () => {
         spyOn((subject as any), "refreshToken");
         await subject.init(injectorMock);
         (subject as any).websocket = websocketBuilder;
-        dispatcherMock.emit("umsLogin");
+        dispatcherMock.emit(DispatchEvents.UMS_LOGIN);
 
         expect((subject as any).refreshToken).toHaveBeenCalled();
       });
@@ -191,7 +184,7 @@ describe("Real Time Module", () => {
 
         spyOn((subject as any), "throwUmsErrorIfNeeded");
         await subject.init(injectorMock);
-        dispatcherMock.emit("umsSwitchUser");
+        dispatcherMock.emit(DispatchEvents.UMS_SWITCH_USER);
 
         expect((subject as any).throwUmsErrorIfNeeded).toHaveBeenCalled();
       });
@@ -202,7 +195,7 @@ describe("Real Time Module", () => {
         spyOn((subject as any), "refreshToken");
         await subject.init(injectorMock);
         (subject as any).websocket = websocketBuilder;
-        dispatcherMock.emit("umsSwitchUser");
+        dispatcherMock.emit(DispatchEvents.UMS_SWITCH_USER);
 
         expect((subject as any).refreshToken).toHaveBeenCalled();
       });
@@ -214,7 +207,7 @@ describe("Real Time Module", () => {
 
         spyOn((subject as any), "throwUmsErrorIfNeeded");
         await subject.init(injectorMock);
-        dispatcherMock.emit("umsLogout");
+        dispatcherMock.emit(DispatchEvents.UMS_LOGOUT);
 
         expect((subject as any).throwUmsErrorIfNeeded).toHaveBeenCalled();
       });
@@ -224,7 +217,7 @@ describe("Real Time Module", () => {
 
         spyOn((subject as any), "closeConnection");
         await subject.init(injectorMock);
-        dispatcherMock.emit("umsLogout");
+        dispatcherMock.emit(DispatchEvents.UMS_LOGOUT);
 
         expect((subject as any).closeConnection).toHaveBeenCalled();
       });
@@ -385,7 +378,7 @@ describe("Real Time Module", () => {
         webSocketMock.onclose({});
       }, 100);
       await subject.terminate();
-      dispatcherEvents.forEach(
+      Object.values(DispatchEvents).forEach(
         (event, key) => expect(dispatcherMock.off).toHaveBeenNthCalledWith(key + 1, event, "rtcConnect"),
       );
     });

--- a/src/api/realtime/realTimeModule.spec.ts
+++ b/src/api/realtime/realTimeModule.spec.ts
@@ -12,6 +12,13 @@ import { RealTimeModule } from "./realTimeModule";
 describe("Real Time Module", () => {
 
   const shouldHaveFailed = "Should have failed!";
+  const dispatchEvents = [
+    DispatchEvents.TOKEN_LOGIN,
+    DispatchEvents.TOKEN_REFRESH,
+    DispatchEvents.UMS_LOGIN,
+    DispatchEvents.UMS_SWITCH_USER,
+    DispatchEvents.UMS_LOGOUT,
+  ];
 
   function createSubject({
     webSocketMock = createMockFor(["send", "close"]) as SpyObj<IWebSocket>,
@@ -100,7 +107,7 @@ describe("Real Time Module", () => {
   });
 
   describe("listen to system events", () => {
-    Object.values(DispatchEvents).forEach(event => {
+    dispatchEvents.forEach(event => {
       it(`should subscribe to the event ${event}`, async () => {
         const { subject, dispatcherMock, injectorMock } = createSubject();
 
@@ -378,7 +385,7 @@ describe("Real Time Module", () => {
         webSocketMock.onclose({});
       }, 100);
       await subject.terminate();
-      Object.values(DispatchEvents).forEach(
+      dispatchEvents.forEach(
         (event, key) => expect(dispatcherMock.off).toHaveBeenNthCalledWith(key + 1, event, "rtcConnect"),
       );
     });

--- a/src/api/realtime/realTimeModule.ts
+++ b/src/api/realtime/realTimeModule.ts
@@ -5,7 +5,7 @@ import { MESSAGE, getRtcUrl } from "../../config";
 import { RequestExecuter } from "../../internal/executer";
 import { IModule, ModuleConfiguration } from "../core/module";
 import { IResource } from "../core/resource";
-import { Dispatcher } from "../core/dispatcher";
+import { Dispatcher, DispatchEvents } from "../core/dispatcher";
 import { AuthOptions, IAuthOptions, TokenManager } from "../core/tokenManager";
 import { Dataset } from "../dataops/dataset";
 import { IFormData } from "../fileops/fileops.interfaces";
@@ -142,11 +142,11 @@ export class RealTimeModule implements IModule {
     const closedConnectionPromise = this.closeConnection();
 
     // unsubscribe from the events
-    this.dispatcher.off("tokenLogin", "rtcConnect");
-    this.dispatcher.off("tokenRefresh", "rtcConnect");
-    this.dispatcher.off("umsLogin", "rtcConnect");
-    this.dispatcher.off("umsSwitchUser", "rtcConnect");
-    this.dispatcher.off("umsLogout", "rtcConnect");
+    this.dispatcher.off(DispatchEvents.TOKEN_LOGIN, "rtcConnect");
+    this.dispatcher.off(DispatchEvents.TOKEN_REFRESH, "rtcConnect");
+    this.dispatcher.off(DispatchEvents.UMS_LOGIN, "rtcConnect");
+    this.dispatcher.off(DispatchEvents.UMS_SWITCH_USER, "rtcConnect");
+    this.dispatcher.off(DispatchEvents.UMS_LOGOUT, "rtcConnect");
 
     return closedConnectionPromise;
   }
@@ -158,7 +158,7 @@ export class RealTimeModule implements IModule {
    */
   private listenToEvents(): void {
     // Listing to the event when the tokenManger did login via jexiaClient().init() with the given keys
-    this.dispatcher.on("tokenLogin", "rtcConnect", async () => {
+    this.dispatcher.on(DispatchEvents.TOKEN_LOGIN, "rtcConnect", async () => {
       if(!this.websocket) {
         this.tokensGivenOnInit = true;
         await this.connect();
@@ -166,14 +166,14 @@ export class RealTimeModule implements IModule {
     });
 
     // Listing to the event when the TokenManager did a refresh
-    this.dispatcher.on("tokenRefresh", "rtcConnect", async () => {
+    this.dispatcher.on(DispatchEvents.TOKEN_REFRESH, "rtcConnect", async () => {
       if(this.websocket) {
         this.refreshToken();
       }
     });
 
     // Listing to the event when the UMS did a login
-    this.dispatcher.on("umsLogin", "rtcConnect", async () => {
+    this.dispatcher.on(DispatchEvents.UMS_LOGIN, "rtcConnect", async () => {
       this.throwUmsErrorIfNeeded();
 
       if(this.websocket) {
@@ -186,7 +186,7 @@ export class RealTimeModule implements IModule {
     });
 
     // Listing to the event when the UMS did a switch between users
-    this.dispatcher.on("umsSwitchUser", "rtcConnect", async () => {
+    this.dispatcher.on(DispatchEvents.UMS_SWITCH_USER, "rtcConnect", async () => {
       this.throwUmsErrorIfNeeded();
 
       if(this.websocket) {
@@ -195,7 +195,7 @@ export class RealTimeModule implements IModule {
     });
 
     // Listing to the event when the UMS did a logout
-    this.dispatcher.on("umsLogout", "rtcConnect", async () => {
+    this.dispatcher.on(DispatchEvents.UMS_LOGOUT, "rtcConnect", async () => {
       this.throwUmsErrorIfNeeded();
 
       await this.closeConnection();

--- a/src/api/ums/umsModule.spec.ts
+++ b/src/api/ums/umsModule.spec.ts
@@ -12,7 +12,7 @@ import { DeleteQuery } from "../core/queries/deleteQuery";
 import { SelectQuery } from "../core/queries/selectQuery";
 import { UpdateQuery } from "../core/queries/updateQuery";
 import { AuthOptions, TokenManager } from "../core/tokenManager";
-import { Dispatcher } from "../core/dispatcher";
+import { Dispatcher, DispatchEvents } from "../core/dispatcher";
 import { UMSModule } from "./umsModule";
 import { OAuthActionType } from "./ums.types";
 import { getSignInParams } from "./ums.functions";
@@ -330,7 +330,7 @@ describe("UMS Module", () => {
         await init();
         await subject.signIn(user).toPromise();
 
-        expect(dispatcherMock.emit).toHaveBeenCalledWith("umsLogin");
+        expect(dispatcherMock.emit).toHaveBeenCalledWith(DispatchEvents.UMS_LOGIN);
       });
     });
 
@@ -416,7 +416,7 @@ describe("UMS Module", () => {
       await init();
       subject.signOut();
 
-      expect(dispatcherMock.emit).toHaveBeenCalledWith("umsLogout");
+      expect(dispatcherMock.emit).toHaveBeenCalledWith(DispatchEvents.UMS_LOGOUT);
     });
   });
 
@@ -503,7 +503,7 @@ describe("UMS Module", () => {
       await init();
       subject.switchUser(signInOptions.alias);
 
-      expect(dispatcherMock.emit).toHaveBeenCalledWith("umsSwitchUser");
+      expect(dispatcherMock.emit).toHaveBeenCalledWith(DispatchEvents.UMS_SWITCH_USER);
     });
   });
 

--- a/src/api/ums/umsModule.ts
+++ b/src/api/ums/umsModule.ts
@@ -10,7 +10,7 @@ import { DeleteQuery } from "../core/queries/deleteQuery";
 import { SelectQuery } from "../core/queries/selectQuery";
 import { UpdateQuery } from "../core/queries/updateQuery";
 import { ResourceType } from "../core/resource";
-import { Dispatcher } from "../core/dispatcher";
+import { Dispatcher, DispatchEvents } from "../core/dispatcher";
 import { AuthOptions, TokenManager, Tokens } from "../core/tokenManager";
 import { UsersInterface, IUMSSignInOptions, IUMSSignUpFields, IUMOAuthInitOptions } from "./ums.types";
 import { getSignInParams } from "./ums.functions";
@@ -110,7 +110,7 @@ export class UMSModule<
         return tokens.access_token;
       }),
       switchMap(() => this.getUser(alias)),
-      tap(() => this.dispatcher.emit("umsLogin")),
+      tap(() => this.dispatcher.emit(DispatchEvents.UMS_LOGIN)),
     );
   }
 
@@ -134,7 +134,7 @@ export class UMSModule<
 
     this.currentUserObject = null;
 
-    this.dispatcher.emit("umsLogout");
+    this.dispatcher.emit(DispatchEvents.UMS_LOGOUT);
   }
 
   /**
@@ -192,7 +192,7 @@ export class UMSModule<
       throw new Error(MESSAGE.TOKEN_MANAGER.ALIAS_NOT_FOUND);
     }
 
-    this.dispatcher.emit("umsSwitchUser");
+    this.dispatcher.emit(DispatchEvents.UMS_SWITCH_USER);
 
     this.tokenManager.setDefault(alias);
   }

--- a/src/internal/utils/index.ts
+++ b/src/internal/utils/index.ts
@@ -28,7 +28,7 @@ export function clone<T>(o: T): T {
 }
 
 export function randomNumber(): number {
-  return Date.now() * Math.floor(Math.random() * 100);
+  return Date.now() * Math.floor(Math.random() * 10000);
 }
 
 export * from "./queryActionType";

--- a/src/internal/utils/index.ts
+++ b/src/internal/utils/index.ts
@@ -27,6 +27,10 @@ export function clone<T>(o: T): T {
   return Object.assign(Object.create(Object.getPrototypeOf(o)), o);
 }
 
+export function randomNumber(): number {
+  return Date.now() * Math.floor(Math.random() * 100);
+}
+
 export * from "./queryActionType";
 export * from "./queryParam";
 export * from "./token";


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is no way to subscribe to events that are fired in the SDK.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
We exposed a `.on()` method on the client to subscribe on SDK events.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
