### PR TITLE
fix(rtc): open-close-open will fail to send new messages

### DIFF
--- a/src/api/realtime/realTimeModule.ts
+++ b/src/api/realtime/realTimeModule.ts
@@ -266,7 +266,10 @@ export class RealTimeModule implements IModule {
 
     // close the websocket connection
     return new Promise((resolve, reject) => {
-      this.websocket.onclose = () => resolve(this);
+      this.websocket.onclose = () => {
+        websocket.reset();
+        return resolve(this);
+      };
       this.websocket.onerror = (err) => reject(err);
       this.websocket.close();
       this.websocket = undefined as unknown as IWebSocket;

--- a/src/api/realtime/websocket.ts
+++ b/src/api/realtime/websocket.ts
@@ -16,10 +16,12 @@ import {
   SubscriptionArgument,
 } from "./realTime.interfaces";
 
+// TODO Refactor Websocket to make use of the WS from RXJS for better socket management
+
 /**
  * @internal
  */
-export const wsReadyDefer = deferPromise();
+export let wsReadyDefer = deferPromise();
 
 /**
  * @internal
@@ -93,6 +95,17 @@ export function refreshToken(webSocket: IWebSocket, getToken: IGetToken): void {
     command: RealTimeCommandTypes.JwtRefresh,
     arguments: { token },
   }));
+}
+
+/**
+ * Reset all values to initial value, so we support closing and open a new connection in one browser session
+ *
+ * @internal
+ */
+export function reset() {
+  wsReadyDefer = deferPromise();
+  responseStack.clear();
+  messageSubscriptions.clear();
 }
 
 /**

--- a/src/api/realtime/websocket.ts
+++ b/src/api/realtime/websocket.ts
@@ -98,7 +98,7 @@ export function refreshToken(webSocket: IWebSocket, getToken: IGetToken): void {
 }
 
 /**
- * Reset all values to initial value, so we support closing and open a new connection in one browser session
+ * Reset all properties to their initial values, so we support closing and open a new connection in one browser session
  *
  * @internal
  */


### PR DESCRIPTION
## PR Checklist

<!-- Please check out our Contribution Guide and our Code of Conduct for complete instructions. -->

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [our conventions](../CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently the RTC wont send any new messages after a user is login - logout - login again. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
It will handle open - close - open connections better.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
